### PR TITLE
Change default model directory to shared ElBruno parent folder

### DIFF
--- a/src/ElBruno.QwenTTS.Core/Pipeline/ModelDownloader.cs
+++ b/src/ElBruno.QwenTTS.Core/Pipeline/ModelDownloader.cs
@@ -13,13 +13,13 @@ public sealed class ModelDownloader
     private const string HfApiBase = "https://huggingface.co/api/models";
 
     /// <summary>
-    /// Default shared model directory: %LOCALAPPDATA%/ElBruno.QwenTTS/models (Windows)
-    /// or ~/.local/share/ElBruno.QwenTTS/models (Linux/macOS).
+    /// Default shared model directory: %LOCALAPPDATA%/ElBruno/QwenTTS (Windows)
+    /// or ~/.local/share/ElBruno/QwenTTS (Linux/macOS).
     /// All apps using the Core library share this location to avoid duplicate downloads.
     /// </summary>
     public static string DefaultModelDir =>
         Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                     "ElBruno.QwenTTS", "models");
+                     "ElBruno", "QwenTTS");
 
     private static readonly string[] ExpectedFiles =
     [


### PR DESCRIPTION
## Summary

Changes the default model download directory from:
- **Before:** `%LOCALAPPDATA%\ElBruno.QwenTTS\models`
- **After:** `%LOCALAPPDATA%\ElBruno\QwenTTS`

This enables a cleaner shared folder structure under `ElBruno/` for multiple projects.

### Changes
- Updated `DefaultModelDir` in `ModelDownloader.cs`
- Updated XML doc comment to reflect new path

### Breaking Change
Users with models at the old path will need to move them or re-download (~5.5 GB).

Closes #1