### PR TITLE
Add voice cloning support with Qwen3-TTS Base model

### DIFF
--- a/ElBruno.QwenTTS.slnx
+++ b/ElBruno.QwenTTS.slnx
@@ -5,5 +5,7 @@
     <Project Path="src/ElBruno.QwenTTS.FileReader/ElBruno.QwenTTS.FileReader.csproj" />
     <Project Path="src/ElBruno.QwenTTS.Web/ElBruno.QwenTTS.Web.csproj" />
     <Project Path="src/ElBruno.QwenTTS.Core.Tests/ElBruno.QwenTTS.Core.Tests.csproj" />
+    <Project Path="src/ElBruno.QwenTTS.VoiceCloning/ElBruno.QwenTTS.VoiceCloning.csproj" />
+    <Project Path="src/ElBruno.QwenTTS.VoiceCloning.Tests/ElBruno.QwenTTS.VoiceCloning.Tests.csproj" />
   </Folder>
 </Solution>

--- a/README.md
+++ b/README.md
@@ -10,16 +10,18 @@
 Run **Qwen3-TTS** text-to-speech locally from C# using ONNX Runtime — no Python needed at inference time. Models are downloaded automatically on first run.
 
 Pre-exported ONNX models are hosted on HuggingFace:
-[**elbruno/Qwen3-TTS-12Hz-0.6B-CustomVoice-ONNX**](https://huggingface.co/elbruno/Qwen3-TTS-12Hz-0.6B-CustomVoice-ONNX)
+[**elbruno/Qwen3-TTS-12Hz-0.6B-CustomVoice-ONNX**](https://huggingface.co/elbruno/Qwen3-TTS-12Hz-0.6B-CustomVoice-ONNX) (preset voices) |
+[**elbruno/Qwen3-TTS-12Hz-0.6B-Base-ONNX**](https://huggingface.co/elbruno/Qwen3-TTS-12Hz-0.6B-Base-ONNX) (voice cloning)
 
 ## Features
 
 - **Local TTS Inference** — Run Qwen3-TTS entirely on your machine using ONNX Runtime
 - **Automatic Model Download** — Models download from HuggingFace on first run (~5.5 GB)
 - **Multi-Speaker** — 9 built-in voices: ryan, serena, vivian, aiden, eric, dylan, uncle_fu, ono_anna, sohee
+- **Voice Cloning** — Clone any voice from a 3-second audio sample ([docs](docs/voice-cloning.md))
 - **Multi-Language** — English, Spanish, Chinese, Japanese, Korean
 - **Voice Control** — Instruction-based style (e.g., "speak with excitement")
-- **Shared Model Cache** — Models stored once in `%LOCALAPPDATA%/ElBruno.QwenTTS/models`, shared across all apps
+- **Shared Model Cache** — Models stored once in `%LOCALAPPDATA%/ElBruno/QwenTTS`, shared across all apps
 - **24 kHz WAV Output** — High-quality mono audio
 
 ---
@@ -49,6 +51,23 @@ dotnet run --project src/ElBruno.QwenTTS -- --model-dir models --text "Hello, th
 ```
 
 Models are downloaded automatically if not present in the `--model-dir` directory.
+
+### Voice Cloning
+
+Clone any voice from a 3-second audio sample using the `ElBruno.QwenTTS.VoiceCloning` package:
+
+```bash
+dotnet add package ElBruno.QwenTTS.VoiceCloning
+```
+
+```csharp
+using ElBruno.QwenTTS.VoiceCloning.Pipeline;
+
+var cloner = await VoiceClonePipeline.CreateAsync();
+await cloner.SynthesizeAsync("Hello world!", "reference_speaker.wav", "output.wav", "english");
+```
+
+See [docs/voice-cloning.md](docs/voice-cloning.md) for full documentation.
 
 ## More Examples
 

--- a/docs/voice-cloning.md
+++ b/docs/voice-cloning.md
@@ -1,0 +1,111 @@
+# Voice Cloning with Qwen3-TTS Base Model
+
+Clone any voice from a 3-second audio sample using the Qwen3-TTS Base model with ECAPA-TDNN speaker encoder.
+
+## Overview
+
+The `ElBruno.QwenTTS.VoiceCloning` NuGet package extends the core TTS library with voice cloning capabilities. It uses:
+
+- **ECAPA-TDNN Speaker Encoder** — extracts a 1024-dim speaker embedding from reference audio
+- **Qwen3-TTS Base Model** — generates speech conditioned on the speaker embedding
+- **Mel-spectrogram DSP** — preprocesses audio for the speaker encoder (24 kHz, 128 mel bins)
+
+## Installation
+
+```bash
+dotnet add package ElBruno.QwenTTS.VoiceCloning
+```
+
+This automatically includes `ElBruno.QwenTTS` (the core library) as a dependency.
+
+## Quick Start
+
+```csharp
+using ElBruno.QwenTTS.VoiceCloning.Pipeline;
+
+// Create pipeline (auto-downloads ~5.5 GB Base model on first run)
+var cloner = await VoiceClonePipeline.CreateAsync();
+
+// Clone a voice from reference audio
+await cloner.SynthesizeAsync(
+    text: "Hello, this is my cloned voice!",
+    referenceAudioPath: "reference_speaker.wav",
+    outputPath: "cloned_output.wav",
+    language: "english"
+);
+```
+
+## Advanced Usage
+
+### Reuse Speaker Embeddings
+
+For multiple utterances with the same cloned voice, extract the embedding once:
+
+```csharp
+var cloner = await VoiceClonePipeline.CreateAsync();
+
+// Extract embedding once
+var embedding = cloner.ExtractSpeakerEmbedding("reference_speaker.wav");
+
+// Synthesize multiple utterances with the same voice
+await cloner.SynthesizeWithEmbeddingAsync("First sentence.", embedding, "out1.wav", "english");
+await cloner.SynthesizeWithEmbeddingAsync("Second sentence.", embedding, "out2.wav", "english");
+await cloner.SynthesizeWithEmbeddingAsync("Third sentence.", embedding, "out3.wav", "english");
+```
+
+### Custom Model Directory
+
+```csharp
+var cloner = await VoiceClonePipeline.CreateAsync(
+    modelDir: @"C:\my\custom\model\path"
+);
+```
+
+## Reference Audio Tips
+
+For best voice cloning results:
+- Use **3+ seconds** of clear speech
+- **24 kHz mono WAV** is preferred (other formats are auto-converted)
+- Minimize background noise
+- Avoid music or overlapping speakers
+- The speaker encoder is robust to recording quality, but cleaner audio = better results
+
+## Model Details
+
+| Component | File | Size | Purpose |
+|-----------|------|------|---------|
+| Speaker Encoder | `speaker_encoder.onnx` | ~34 MB | ECAPA-TDNN voice embedding |
+| Talker Prefill | `talker_prefill.onnx` | ~1.7 GB | Language model (full sequence) |
+| Talker Decode | `talker_decode.onnx` | ~1.7 GB | Language model (autoregressive) |
+| Code Predictor | `code_predictor.onnx` | ~440 MB | Codebook generation |
+| Vocoder | `vocoder.onnx` | ~2.7 MB | Audio codes → waveform |
+| Embeddings | `embeddings/*.npy` | ~1.4 GB | Lookup tables |
+
+**Total download:** ~5.5 GB (stored at `%LOCALAPPDATA%\ElBruno\QwenTTS-Base`)
+
+## Differences from Standard TTS
+
+| Feature | `ElBruno.QwenTTS` | `ElBruno.QwenTTS.VoiceCloning` |
+|---------|-------------------|-------------------------------|
+| Model | CustomVoice (9 preset speakers) | Base (any voice) |
+| Input | Text + speaker name | Text + reference audio |
+| Speaker selection | `"ryan"`, `"emily"`, etc. | Any WAV file |
+| Extra dependency | None | Speaker encoder + mel DSP |
+
+## Python Export Scripts
+
+The ONNX models were exported using the scripts in `python/`:
+
+```bash
+# Download Base model weights
+python download_models.py --model base
+
+# Export speaker encoder
+python export_speaker_encoder.py --model-dir models/Qwen3-TTS-0.6B-Base --output-dir onnx_base/
+
+# Export LM (talker + code predictor)
+python export_lm.py --model-dir models/Qwen3-TTS-0.6B-Base --output-dir onnx_base/
+
+# Export embeddings
+python export_embeddings.py --model-dir models/Qwen3-TTS-0.6B-Base --output-dir onnx_base/embeddings
+```

--- a/python/download_models.py
+++ b/python/download_models.py
@@ -2,23 +2,37 @@
 Download Qwen3-TTS model weights from Hugging Face Hub.
 
 Models downloaded:
-  - Qwen/Qwen3-TTS-0.6B-CustomVoice  (the language model)
-  - Qwen/Qwen3-TTS-Tokenizer-12Hz    (the vocoder / speech tokenizer)
+  - Qwen/Qwen3-TTS-0.6B-CustomVoice  (the language model — CustomVoice variant)
+  - Qwen/Qwen3-TTS-12Hz-0.6B-Base    (the language model — Base variant with voice cloning)
+  - Qwen/Qwen3-TTS-Tokenizer-12Hz    (the vocoder / speech tokenizer, shared)
 
 Usage:
-  python download_models.py
+  python download_models.py                    # Download all models
+  python download_models.py --model base       # Download Base model only
+  python download_models.py --model customvoice # Download CustomVoice model only
 """
 
+import argparse
 import os
 from pathlib import Path
 from huggingface_hub import snapshot_download
 
 
-MODELS = [
+CUSTOM_VOICE_MODELS = [
     {
         "repo_id": "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice",
         "local_dir": "Qwen3-TTS-0.6B-CustomVoice",
     },
+]
+
+BASE_MODELS = [
+    {
+        "repo_id": "Qwen/Qwen3-TTS-12Hz-0.6B-Base",
+        "local_dir": "Qwen3-TTS-0.6B-Base",
+    },
+]
+
+SHARED_MODELS = [
     {
         "repo_id": "Qwen/Qwen3-TTS-Tokenizer-12Hz",
         "local_dir": "Qwen3-TTS-Tokenizer-12Hz",
@@ -29,10 +43,26 @@ MODELS_DIR = Path(__file__).parent / "models"
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Download Qwen3-TTS model weights")
+    parser.add_argument(
+        "--model",
+        type=str,
+        choices=["all", "base", "customvoice"],
+        default="all",
+        help="Which model variant to download (default: all)",
+    )
+    args = parser.parse_args()
+
     MODELS_DIR.mkdir(parents=True, exist_ok=True)
     print(f"Downloading models to {MODELS_DIR.resolve()}\n")
 
-    for model in MODELS:
+    models = list(SHARED_MODELS)
+    if args.model in ("all", "customvoice"):
+        models.extend(CUSTOM_VOICE_MODELS)
+    if args.model in ("all", "base"):
+        models.extend(BASE_MODELS)
+
+    for model in models:
         dest = MODELS_DIR / model["local_dir"]
         print(f"--- {model['repo_id']} → {dest}")
         snapshot_download(

--- a/python/export_speaker_encoder.py
+++ b/python/export_speaker_encoder.py
@@ -1,0 +1,155 @@
+"""
+Export ECAPA-TDNN Speaker Encoder to ONNX.
+
+Creates:
+  speaker_encoder.onnx — Speaker encoder for voice cloning (Base model only)
+
+Input:  mel_spectrogram (1, T_mel, 128) float32  — 128-dim mel-spectrogram (time-first)
+Output: speaker_embedding (1, 1024) float32       — x-vector speaker embedding
+
+Usage:
+  python export_speaker_encoder.py --model-dir models/Qwen3-TTS-0.6B-Base --output-dir onnx_base/
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+import onnx
+import onnxruntime as ort
+from qwen_tts.core.models.modeling_qwen3_tts import Qwen3TTSForConditionalGeneration
+from qwen_tts.core.models.configuration_qwen3_tts import Qwen3TTSConfig
+
+
+OPSET_VERSION = 17
+
+
+class SpeakerEncoderWrapper(nn.Module):
+    """Wraps the ECAPA-TDNN speaker encoder for clean ONNX export."""
+
+    def __init__(self, speaker_encoder):
+        super().__init__()
+        self.encoder = speaker_encoder
+
+    def forward(self, mel_spectrogram: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            mel_spectrogram: (B, T_mel, n_mels) float32 — time-first layout
+        Returns:
+            speaker_embedding: (B, enc_dim) float32
+        """
+        return self.encoder(mel_spectrogram)
+
+
+def export_speaker_encoder(model_dir: str, output_dir: str):
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading model from {model_dir} ...")
+    config = Qwen3TTSConfig.from_pretrained(model_dir)
+    model = Qwen3TTSForConditionalGeneration.from_pretrained(
+        model_dir, config=config, dtype=torch.float32
+    )
+    model.eval()
+
+    if not hasattr(model, "speaker_encoder") or model.speaker_encoder is None:
+        raise RuntimeError(
+            "This model does not have a speaker encoder. "
+            "Use the Base model (not CustomVoice) for voice cloning."
+        )
+
+    se = model.speaker_encoder
+    wrapper = SpeakerEncoderWrapper(se)
+    wrapper.eval()
+
+    # Dummy input: (batch=1, T_mel=300, n_mels=128) — ~2.5s of audio at 24kHz/256 hop
+    # The encoder internally transposes to (B, n_mels, T_mel) for Conv1d
+    n_mels = config.speaker_encoder_config.mel_dim
+    dummy_mel = torch.randn(1, 300, n_mels)
+
+    # Run PyTorch reference
+    with torch.no_grad():
+        ref_output = wrapper(dummy_mel)
+    print(f"PyTorch output shape: {ref_output.shape}")
+
+    # Export to ONNX
+    onnx_path = output_path / "speaker_encoder.onnx"
+    print(f"\nExporting to {onnx_path} ...")
+    torch.onnx.export(
+        wrapper,
+        (dummy_mel,),
+        str(onnx_path),
+        opset_version=OPSET_VERSION,
+        input_names=["mel_spectrogram"],
+        output_names=["speaker_embedding"],
+        dynamic_axes={
+            "mel_spectrogram": {0: "batch", 1: "time"},
+            "speaker_embedding": {0: "batch"},
+        },
+    )
+    print(f"  ✓ Exported {onnx_path.name}")
+
+    # Validate ONNX model
+    print("\nValidating ONNX model ...")
+    onnx_model = onnx.load(str(onnx_path))
+    onnx.checker.check_model(onnx_model)
+    print("  ✓ ONNX model is valid")
+
+    # Compare outputs
+    sess = ort.InferenceSession(str(onnx_path))
+    ort_output = sess.run(None, {"mel_spectrogram": dummy_mel.numpy()})[0]
+    ort_tensor = torch.from_numpy(ort_output)
+
+    # Cosine similarity
+    cos_sim = torch.nn.functional.cosine_similarity(
+        ref_output.flatten(), ort_tensor.flatten(), dim=0
+    ).item()
+
+    # Max absolute error
+    max_err = (ref_output - ort_tensor).abs().max().item()
+
+    print(f"  Cosine similarity: {cos_sim:.6f}")
+    print(f"  Max absolute error: {max_err:.6e}")
+
+    if cos_sim > 0.999:
+        print("  ✓ PASS: Cosine similarity > 0.999")
+    else:
+        print("  ✗ FAIL: Cosine similarity too low!")
+
+    # Test with different sequence lengths
+    print("\nTesting dynamic time axis ...")
+    for t in [100, 500, 1000]:
+        test_mel = torch.randn(1, t, n_mels)
+        with torch.no_grad():
+            pt_out = wrapper(test_mel)
+        ort_out = sess.run(None, {"mel_spectrogram": test_mel.numpy()})[0]
+        err = np.abs(pt_out.numpy() - ort_out).max()
+        print(f"  T={t:4d}: shape={ort_out.shape}, max_err={err:.6e}")
+
+    print(f"\nSpeaker encoder exported to {onnx_path.resolve()}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export ECAPA-TDNN speaker encoder to ONNX"
+    )
+    parser.add_argument(
+        "--model-dir",
+        type=str,
+        default="models/Qwen3-TTS-0.6B-Base",
+        help="Path to the Qwen3-TTS Base model directory",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="onnx_base",
+        help="Directory to save speaker_encoder.onnx",
+    )
+    args = parser.parse_args()
+    export_speaker_encoder(args.model_dir, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/upload_base_to_hf.py
+++ b/python/upload_base_to_hf.py
@@ -1,0 +1,103 @@
+"""Upload Base model ONNX files to HuggingFace."""
+from pathlib import Path
+from huggingface_hub import HfApi, create_repo
+
+repo_id = "elbruno/Qwen3-TTS-12Hz-0.6B-Base-ONNX"
+print(f"Creating repo {repo_id}...")
+create_repo(repo_id, repo_type="model", exist_ok=True, private=False)
+
+api = HfApi()
+onnx_dir = Path("onnx_base")
+
+# Upload ONNX models
+onnx_files = sorted(list(onnx_dir.glob("*.onnx")) + list(onnx_dir.glob("*.onnx.data")))
+print(f"Uploading {len(onnx_files)} ONNX files...")
+for f in onnx_files:
+    size_mb = f.stat().st_size / (1024 * 1024)
+    print(f"  -> {f.name} ({size_mb:.1f} MB)")
+    api.upload_file(path_or_fileobj=str(f), path_in_repo=f.name, repo_id=repo_id)
+
+# Upload embeddings
+emb_dir = onnx_dir / "embeddings"
+emb_files = sorted(emb_dir.iterdir())
+print(f"Uploading {len(emb_files)} embedding files...")
+for f in emb_files:
+    if f.is_file():
+        size_mb = f.stat().st_size / (1024 * 1024)
+        print(f"  -> embeddings/{f.name} ({size_mb:.1f} MB)")
+        api.upload_file(
+            path_or_fileobj=str(f),
+            path_in_repo=f"embeddings/{f.name}",
+            repo_id=repo_id,
+        )
+
+# Upload tokenizer
+tok_dir = onnx_dir / "tokenizer"
+print("Uploading tokenizer files...")
+for name in ["vocab.json", "merges.txt"]:
+    f = tok_dir / name
+    if f.exists():
+        print(f"  -> tokenizer/{name}")
+        api.upload_file(
+            path_or_fileobj=str(f), path_in_repo=f"tokenizer/{name}", repo_id=repo_id
+        )
+
+# Upload README
+readme = """---
+license: apache-2.0
+tags:
+  - onnx
+  - tts
+  - qwen3-tts
+  - text-to-speech
+  - voice-cloning
+  - ecapa-tdnn
+base_model: Qwen/Qwen3-TTS-12Hz-0.6B-Base
+---
+
+# Qwen3-TTS 12Hz 0.6B Base — ONNX (Voice Cloning)
+
+ONNX export of [Qwen/Qwen3-TTS-12Hz-0.6B-Base](https://huggingface.co/Qwen/Qwen3-TTS-12Hz-0.6B-Base) for local inference with C# / ONNX Runtime. Includes ECAPA-TDNN speaker encoder for 3-second voice cloning.
+
+## Files
+
+| File | Description | Size |
+|------|-------------|------|
+| `speaker_encoder.onnx` + `.data` | ECAPA-TDNN speaker encoder | ~34 MB |
+| `talker_prefill.onnx` + `.data` | Talker LM prefill (28 layers) | ~1.7 GB |
+| `talker_decode.onnx` + `.data` | Talker LM single-step decode | ~1.7 GB |
+| `code_predictor.onnx` | Code Predictor (5 layers, 15 groups) | ~440 MB |
+| `vocoder.onnx` | Vocoder decoder (24kHz output) | ~2.7 MB |
+| `embeddings/` | Text/codec embeddings as .npy + config | ~1.4 GB |
+| `tokenizer/` | BPE tokenizer (vocab.json, merges.txt) | ~4 MB |
+
+## Usage with C#
+
+```bash
+dotnet add package ElBruno.QwenTTS.VoiceCloning
+```
+
+```csharp
+using ElBruno.QwenTTS.VoiceCloning.Pipeline;
+
+var cloner = await VoiceClonePipeline.CreateAsync();
+await cloner.SynthesizeAsync("Hello world!", "reference.wav", "output.wav", "english");
+```
+
+## Architecture
+
+- **Speaker Encoder**: ECAPA-TDNN, 128 mel bins input, 1024-dim output
+- **Talker**: 28 transformer layers, 16 attn heads, 8 KV heads, hidden=1024
+- **Code Predictor**: 5 layers, generates codebook groups 1-15
+- **Vocoder**: RVQ dequantize → transformer → BigVGAN decoder, 12Hz → 24kHz
+
+## License
+
+Apache-2.0 (same as base model)
+"""
+print("  -> README.md")
+api.upload_file(
+    path_or_fileobj=readme.encode("utf-8"), path_in_repo="README.md", repo_id=repo_id
+)
+
+print(f"\nAll files uploaded to https://huggingface.co/{repo_id}")

--- a/src/ElBruno.QwenTTS.VoiceCloning.Tests/ElBruno.QwenTTS.VoiceCloning.Tests.csproj
+++ b/src/ElBruno.QwenTTS.VoiceCloning.Tests/ElBruno.QwenTTS.VoiceCloning.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ElBruno.QwenTTS.VoiceCloning\ElBruno.QwenTTS.VoiceCloning.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ElBruno.QwenTTS.VoiceCloning.Tests/VoiceCloningTests.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning.Tests/VoiceCloningTests.cs
@@ -1,0 +1,166 @@
+using Xunit;
+using ElBruno.QwenTTS.VoiceCloning.Audio;
+using ElBruno.QwenTTS.VoiceCloning.Models;
+using ElBruno.QwenTTS.VoiceCloning.Pipeline;
+
+namespace ElBruno.QwenTTS.VoiceCloning.Tests;
+
+public class MelSpectrogramTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public MelSpectrogramTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"vc_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [Fact]
+    public void Extract_ReturnsCorrectShape()
+    {
+        // 1 second of silence at 24 kHz
+        int sampleRate = 24000;
+        int nSamples = sampleRate;
+        var samples = new float[nSamples];
+
+        var mel = MelSpectrogram.Extract(samples, sampleRate);
+
+        // T_mel = 1 + (24000 - 1024) / 256 = 90 frames (approx)
+        Assert.True(mel.GetLength(0) > 0, "Should have at least one frame");
+        Assert.Equal(128, mel.GetLength(1));  // 128 mel bins
+    }
+
+    [Fact]
+    public void Extract_WithSineWave_HasNonZeroEnergy()
+    {
+        int sampleRate = 24000;
+        int nSamples = sampleRate; // 1 second
+        var samples = new float[nSamples];
+
+        // Generate 440 Hz sine wave
+        for (int i = 0; i < nSamples; i++)
+            samples[i] = MathF.Sin(2f * MathF.PI * 440f * i / sampleRate) * 0.5f;
+
+        var mel = MelSpectrogram.Extract(samples, sampleRate);
+
+        // At least some mel bins should have non-trivial energy
+        float maxVal = float.MinValue;
+        for (int t = 0; t < mel.GetLength(0); t++)
+            for (int m = 0; m < mel.GetLength(1); m++)
+                maxVal = Math.Max(maxVal, mel[t, m]);
+
+        Assert.True(maxVal > -20f, "Sine wave should produce significant mel energy");
+    }
+
+    [Fact]
+    public void Extract_ShortAudio_StillWorks()
+    {
+        // Very short audio: 256 samples (one hop)
+        var samples = new float[256];
+        for (int i = 0; i < 256; i++)
+            samples[i] = MathF.Sin(2f * MathF.PI * 1000f * i / 24000);
+
+        var mel = MelSpectrogram.Extract(samples);
+
+        Assert.True(mel.GetLength(0) >= 1, "Should produce at least one frame");
+        Assert.Equal(128, mel.GetLength(1));
+    }
+
+    [Fact]
+    public void FromWavFile_ReadsAndExtracts()
+    {
+        // Create a simple WAV file
+        var wavPath = Path.Combine(_tempDir, "test.wav");
+        int sampleRate = 24000;
+        int nSamples = sampleRate; // 1 second
+        var samples = new float[nSamples];
+        for (int i = 0; i < nSamples; i++)
+            samples[i] = MathF.Sin(2f * MathF.PI * 440f * i / sampleRate) * 0.3f;
+
+        ElBruno.QwenTTS.Audio.WavWriter.Write(wavPath, samples, sampleRate);
+
+        var mel = MelSpectrogram.FromWavFile(wavPath);
+
+        Assert.True(mel.GetLength(0) > 0);
+        Assert.Equal(128, mel.GetLength(1));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+}
+
+public class VoiceCloningDownloaderTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public VoiceCloningDownloaderTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"vc_dl_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    [Fact]
+    public void IsModelDownloaded_EmptyDir_ReturnsFalse()
+    {
+        Assert.False(VoiceCloningDownloader.IsModelDownloaded(_tempDir));
+    }
+
+    [Fact]
+    public void DefaultModelDir_IsUnderElBruno()
+    {
+        var dir = VoiceCloningDownloader.DefaultModelDir;
+        Assert.Contains("ElBruno", dir);
+        Assert.Contains("QwenTTS-Base", dir);
+    }
+
+    [Fact]
+    public async Task DownloadModelAsync_CancellationPreventsDownload()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            VoiceCloningDownloader.DownloadModelAsync(_tempDir, cancellationToken: cts.Token));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+            Directory.Delete(_tempDir, recursive: true);
+    }
+}
+
+public class SpeakerEncoderTests
+{
+    [Fact]
+    public void Constructor_AcceptsModelPath()
+    {
+        // Just verify the constructor doesn't throw (lazy loading)
+        var encoder = new SpeakerEncoder("nonexistent.onnx");
+        Assert.Equal(1024, encoder.EmbeddingDim);
+        Assert.Equal(128, encoder.MelDim);
+        encoder.Dispose();
+    }
+}
+
+public class VoiceClonePipelineTests
+{
+    [Fact]
+    public void Constructor_ThrowsIfSpeakerEncoderMissing()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"vc_pipe_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            Assert.Throws<FileNotFoundException>(() => new VoiceClonePipeline(tempDir));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+}

--- a/src/ElBruno.QwenTTS.VoiceCloning/Audio/MelSpectrogram.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Audio/MelSpectrogram.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Numerics;
+
+namespace ElBruno.QwenTTS.VoiceCloning.Audio;
+
+/// <summary>
+/// Extracts mel-spectrograms from raw audio for the ECAPA-TDNN speaker encoder.
+/// Produces output compatible with Qwen3-TTS Base model expectations:
+/// 24 kHz sample rate, 128 mel bins, hop length 256.
+/// </summary>
+public static class MelSpectrogram
+{
+    private const int DefaultSampleRate = 24000;
+    private const int DefaultNFft = 1024;
+    private const int DefaultHopLength = 256;
+    private const int DefaultNMels = 128;
+    private const float FMin = 0f;
+    private const float FMax = 12000f; // Nyquist for 24 kHz
+
+    /// <summary>
+    /// Extract a mel-spectrogram from raw audio samples.
+    /// </summary>
+    /// <param name="samples">PCM float32 samples at 24 kHz, mono.</param>
+    /// <param name="sampleRate">Sample rate in Hz (default 24000).</param>
+    /// <param name="nFft">FFT window size (default 1024).</param>
+    /// <param name="hopLength">Hop length in samples (default 256).</param>
+    /// <param name="nMels">Number of mel filter banks (default 128).</param>
+    /// <returns>Mel-spectrogram as float[T_mel, n_mels] — time-first layout.</returns>
+    public static float[,] Extract(float[] samples, int sampleRate = DefaultSampleRate,
+                                    int nFft = DefaultNFft, int hopLength = DefaultHopLength,
+                                    int nMels = DefaultNMels)
+    {
+        // Number of frequency bins in the STFT
+        int nFreqs = nFft / 2 + 1;
+
+        // Build Hann window
+        var window = BuildHannWindow(nFft);
+
+        // Build mel filter bank
+        var melFilters = BuildMelFilterBank(nMels, nFreqs, sampleRate, FMin, FMax);
+
+        // Compute STFT frames
+        int numFrames = 1 + (samples.Length - nFft) / hopLength;
+        if (numFrames <= 0)
+            numFrames = 1;
+
+        var melSpec = new float[numFrames, nMels];
+
+        // Scratch buffer for FFT
+        var fftBuffer = new double[nFft];
+        var fftImag = new double[nFft];
+
+        for (int frame = 0; frame < numFrames; frame++)
+        {
+            int start = frame * hopLength;
+
+            // Apply window and copy to FFT buffer
+            for (int i = 0; i < nFft; i++)
+            {
+                int idx = start + i;
+                float sample = idx < samples.Length ? samples[idx] : 0f;
+                fftBuffer[i] = sample * window[i];
+                fftImag[i] = 0;
+            }
+
+            // In-place FFT
+            Fft(fftBuffer, fftImag, nFft);
+
+            // Compute power spectrum and apply mel filters
+            for (int m = 0; m < nMels; m++)
+            {
+                double melEnergy = 0;
+                for (int k = 0; k < nFreqs; k++)
+                {
+                    if (melFilters[m, k] > 0)
+                    {
+                        double real = fftBuffer[k];
+                        double imag = fftImag[k];
+                        double power = real * real + imag * imag;
+                        melEnergy += melFilters[m, k] * power;
+                    }
+                }
+
+                // Log mel: log(max(energy, 1e-10))
+                melSpec[frame, m] = (float)Math.Log(Math.Max(melEnergy, 1e-10));
+            }
+        }
+
+        return melSpec;
+    }
+
+    /// <summary>
+    /// Read a WAV file and extract mel-spectrogram.
+    /// Supports 16-bit PCM WAV at any sample rate (resamples to 24 kHz if needed).
+    /// </summary>
+    public static float[,] FromWavFile(string wavPath)
+    {
+        var (samples, sampleRate) = ReadWav(wavPath);
+
+        if (sampleRate != DefaultSampleRate)
+        {
+            samples = Resample(samples, sampleRate, DefaultSampleRate);
+        }
+
+        return Extract(samples, DefaultSampleRate);
+    }
+
+    private static (float[] samples, int sampleRate) ReadWav(string path)
+    {
+        using var stream = File.OpenRead(path);
+        using var reader = new BinaryReader(stream);
+
+        // RIFF header
+        var riff = new string(reader.ReadChars(4));
+        if (riff != "RIFF") throw new InvalidDataException("Not a WAV file");
+        reader.ReadInt32(); // file size
+        var wave = new string(reader.ReadChars(4));
+        if (wave != "WAVE") throw new InvalidDataException("Not a WAV file");
+
+        // Find fmt chunk
+        int sampleRate = 0;
+        short bitsPerSample = 0;
+        short numChannels = 0;
+
+        while (stream.Position < stream.Length)
+        {
+            var chunkId = new string(reader.ReadChars(4));
+            int chunkSize = reader.ReadInt32();
+
+            if (chunkId == "fmt ")
+            {
+                short audioFormat = reader.ReadInt16();
+                numChannels = reader.ReadInt16();
+                sampleRate = reader.ReadInt32();
+                reader.ReadInt32(); // byte rate
+                reader.ReadInt16(); // block align
+                bitsPerSample = reader.ReadInt16();
+                if (chunkSize > 16)
+                    reader.ReadBytes(chunkSize - 16);
+            }
+            else if (chunkId == "data")
+            {
+                int bytesPerSample = bitsPerSample / 8;
+                int totalSamples = chunkSize / bytesPerSample;
+                int monoSamples = totalSamples / numChannels;
+                var samples = new float[monoSamples];
+
+                for (int i = 0; i < monoSamples; i++)
+                {
+                    double sum = 0;
+                    for (int ch = 0; ch < numChannels; ch++)
+                    {
+                        sum += bitsPerSample switch
+                        {
+                            16 => reader.ReadInt16() / 32768.0,
+                            32 => reader.ReadSingle(),
+                            _ => reader.ReadInt16() / 32768.0
+                        };
+                    }
+                    samples[i] = (float)(sum / numChannels);
+                }
+
+                return (samples, sampleRate);
+            }
+            else
+            {
+                reader.ReadBytes(chunkSize);
+            }
+        }
+
+        throw new InvalidDataException("WAV file has no data chunk");
+    }
+
+    private static float[] Resample(float[] input, int fromRate, int toRate)
+    {
+        double ratio = (double)toRate / fromRate;
+        int outputLen = (int)(input.Length * ratio);
+        var output = new float[outputLen];
+
+        for (int i = 0; i < outputLen; i++)
+        {
+            double srcIdx = i / ratio;
+            int idx0 = (int)srcIdx;
+            int idx1 = Math.Min(idx0 + 1, input.Length - 1);
+            double frac = srcIdx - idx0;
+            output[i] = (float)(input[idx0] * (1 - frac) + input[idx1] * frac);
+        }
+
+        return output;
+    }
+
+    private static float[] BuildHannWindow(int size)
+    {
+        var window = new float[size];
+        for (int i = 0; i < size; i++)
+            window[i] = 0.5f * (1f - MathF.Cos(2f * MathF.PI * i / size));
+        return window;
+    }
+
+    private static float[,] BuildMelFilterBank(int nMels, int nFreqs, int sampleRate, float fMin, float fMax)
+    {
+        var filters = new float[nMels, nFreqs];
+
+        // Convert Hz to mel scale
+        static double HzToMel(double hz) => 2595.0 * Math.Log10(1.0 + hz / 700.0);
+        static double MelToHz(double mel) => 700.0 * (Math.Pow(10.0, mel / 2595.0) - 1.0);
+
+        double melMin = HzToMel(fMin);
+        double melMax = HzToMel(fMax);
+
+        // Create nMels+2 equally spaced mel points
+        var melPoints = new double[nMels + 2];
+        for (int i = 0; i < nMels + 2; i++)
+            melPoints[i] = melMin + (melMax - melMin) * i / (nMels + 1);
+
+        // Convert mel points to FFT bin indices
+        var binIndices = new double[nMels + 2];
+        for (int i = 0; i < nMels + 2; i++)
+            binIndices[i] = MelToHz(melPoints[i]) * (nFreqs - 1) * 2.0 / sampleRate;
+
+        // Build triangular filters
+        for (int m = 0; m < nMels; m++)
+        {
+            double left = binIndices[m];
+            double center = binIndices[m + 1];
+            double right = binIndices[m + 2];
+
+            for (int k = 0; k < nFreqs; k++)
+            {
+                if (k >= left && k <= center && center > left)
+                    filters[m, k] = (float)((k - left) / (center - left));
+                else if (k > center && k <= right && right > center)
+                    filters[m, k] = (float)((right - k) / (right - center));
+            }
+        }
+
+        return filters;
+    }
+
+    /// <summary>
+    /// Cooley-Tukey FFT (radix-2, in-place).
+    /// </summary>
+    private static void Fft(double[] real, double[] imag, int n)
+    {
+        // Bit-reversal permutation
+        int bits = (int)Math.Log2(n);
+        for (int i = 0; i < n; i++)
+        {
+            int j = BitReverse(i, bits);
+            if (j > i)
+            {
+                (real[i], real[j]) = (real[j], real[i]);
+                (imag[i], imag[j]) = (imag[j], imag[i]);
+            }
+        }
+
+        // FFT butterfly
+        for (int size = 2; size <= n; size *= 2)
+        {
+            int half = size / 2;
+            double angle = -2.0 * Math.PI / size;
+
+            for (int i = 0; i < n; i += size)
+            {
+                for (int k = 0; k < half; k++)
+                {
+                    double cos = Math.Cos(angle * k);
+                    double sin = Math.Sin(angle * k);
+
+                    double tReal = cos * real[i + k + half] - sin * imag[i + k + half];
+                    double tImag = sin * real[i + k + half] + cos * imag[i + k + half];
+
+                    real[i + k + half] = real[i + k] - tReal;
+                    imag[i + k + half] = imag[i + k] - tImag;
+                    real[i + k] += tReal;
+                    imag[i + k] += tImag;
+                }
+            }
+        }
+    }
+
+    private static int BitReverse(int x, int bits)
+    {
+        int result = 0;
+        for (int i = 0; i < bits; i++)
+        {
+            result = (result << 1) | (x & 1);
+            x >>= 1;
+        }
+        return result;
+    }
+}

--- a/src/ElBruno.QwenTTS.VoiceCloning/ElBruno.QwenTTS.VoiceCloning.csproj
+++ b/src/ElBruno.QwenTTS.VoiceCloning/ElBruno.QwenTTS.VoiceCloning.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>CS1591</NoWarn>
+    <PackageId>ElBruno.QwenTTS.VoiceCloning</PackageId>
+    <Description>Voice cloning extension for ElBruno.QwenTTS. Clone any voice from a 3-second audio sample using the Qwen3-TTS Base model with ECAPA-TDNN speaker encoder.</Description>
+    <Authors>Bruno Capuano</Authors>
+    <RepositoryUrl>https://github.com/elbruno/ElBruno.QwenTTS</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/elbruno/ElBruno.QwenTTS</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageIcon>nuget_01.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>tts;text-to-speech;voice-cloning;qwen;onnx;ai;local;speech-synthesis;ecapa-tdnn;speaker-encoder</PackageTags>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ElBruno.QwenTTS.Core\ElBruno.QwenTTS.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\..\images\nuget_01.png" Pack="true" PackagePath="\" Link="nuget_01.png" />
+  </ItemGroup>
+
+</Project>

--- a/src/ElBruno.QwenTTS.VoiceCloning/Models/SpeakerEncoder.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Models/SpeakerEncoder.cs
@@ -1,0 +1,88 @@
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+
+namespace ElBruno.QwenTTS.VoiceCloning.Models;
+
+/// <summary>
+/// Wraps the ECAPA-TDNN speaker encoder ONNX model.
+/// Extracts a 1024-dimensional speaker embedding from a mel-spectrogram.
+/// Input: (1, T_mel, 128) float32 — time-first mel-spectrogram.
+/// Output: (1, 1024) float32 — speaker embedding (x-vector).
+/// </summary>
+public sealed class SpeakerEncoder : IDisposable
+{
+    private InferenceSession? _session;
+    private readonly string _modelPath;
+
+    /// <summary>Embedding dimension (1024 for ECAPA-TDNN in Qwen3-TTS).</summary>
+    public int EmbeddingDim => 1024;
+
+    /// <summary>Expected number of mel bins.</summary>
+    public int MelDim => 128;
+
+    public SpeakerEncoder(string modelPath)
+    {
+        _modelPath = modelPath;
+    }
+
+    private InferenceSession GetSession()
+    {
+        if (_session is null)
+        {
+            var options = new SessionOptions
+            {
+                GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
+            };
+            _session = new InferenceSession(_modelPath, options);
+        }
+        return _session;
+    }
+
+    /// <summary>
+    /// Encode a mel-spectrogram into a speaker embedding.
+    /// </summary>
+    /// <param name="melSpectrogram">Mel-spectrogram of shape (T_mel, n_mels), time-first.</param>
+    /// <returns>Speaker embedding of length 1024.</returns>
+    public float[] Encode(float[,] melSpectrogram)
+    {
+        int tMel = melSpectrogram.GetLength(0);
+        int nMels = melSpectrogram.GetLength(1);
+
+        // Create tensor (1, T_mel, n_mels)
+        var tensor = new DenseTensor<float>(new[] { 1, tMel, nMels });
+        for (int t = 0; t < tMel; t++)
+            for (int m = 0; m < nMels; m++)
+                tensor[0, t, m] = melSpectrogram[t, m];
+
+        var inputs = new List<NamedOnnxValue>
+        {
+            NamedOnnxValue.CreateFromTensor("mel_spectrogram", tensor)
+        };
+
+        using var results = GetSession().Run(inputs);
+        var outputTensor = results.First().AsTensor<float>();
+
+        // Copy to flat array
+        var embedding = new float[outputTensor.Length];
+        int i = 0;
+        foreach (var val in outputTensor)
+            embedding[i++] = val;
+
+        return embedding;
+    }
+
+    /// <summary>
+    /// Encode a WAV file into a speaker embedding.
+    /// Convenience method that handles mel-spectrogram extraction.
+    /// </summary>
+    public float[] EncodeFromWav(string wavPath)
+    {
+        var mel = Audio.MelSpectrogram.FromWavFile(wavPath);
+        return Encode(mel);
+    }
+
+    public void Dispose()
+    {
+        _session?.Dispose();
+    }
+}

--- a/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceClonePipeline.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceClonePipeline.cs
@@ -1,0 +1,140 @@
+using ElBruno.QwenTTS.Audio;
+using ElBruno.QwenTTS.Models;
+using ElBruno.QwenTTS.Pipeline;
+using ElBruno.QwenTTS.VoiceCloning.Models;
+
+namespace ElBruno.QwenTTS.VoiceCloning.Pipeline;
+
+/// <summary>
+/// Orchestrates the voice cloning TTS pipeline:
+/// reference audio → mel-spectrogram → speaker encoder → LM → vocoder → WAV.
+/// 
+/// Uses the Qwen3-TTS Base model (not CustomVoice) with ECAPA-TDNN speaker encoder
+/// for 3-second voice cloning from arbitrary reference audio.
+/// </summary>
+public sealed class VoiceClonePipeline : IDisposable
+{
+    private readonly TextTokenizer _tokenizer;
+    private readonly LanguageModel _languageModel;
+    private readonly Vocoder _vocoder;
+    private readonly EmbeddingStore _embeddings;
+    private readonly SpeakerEncoder _speakerEncoder;
+
+    public VoiceClonePipeline(string modelDir)
+    {
+        var tokenizerDir = Path.Combine(modelDir, "tokenizer");
+        var embeddingsDir = Path.Combine(modelDir, "embeddings");
+        var configPath = Path.Combine(embeddingsDir, "config.json");
+        var speakerEncoderPath = Path.Combine(modelDir, "speaker_encoder.onnx");
+
+        if (!File.Exists(speakerEncoderPath))
+            throw new FileNotFoundException(
+                "Speaker encoder model not found. Use the Base model (not CustomVoice) for voice cloning.",
+                speakerEncoderPath);
+
+        _tokenizer = new TextTokenizer(tokenizerDir);
+        _embeddings = new EmbeddingStore(embeddingsDir, configPath);
+        _languageModel = new LanguageModel(modelDir, _embeddings);
+        _vocoder = new Vocoder(Path.Combine(modelDir, "vocoder.onnx"));
+        _speakerEncoder = new SpeakerEncoder(speakerEncoderPath);
+    }
+
+    /// <summary>
+    /// Extract a speaker embedding from a reference audio WAV file.
+    /// The returned embedding can be reused across multiple synthesis calls
+    /// with the same voice.
+    /// </summary>
+    /// <param name="referenceAudioPath">Path to a WAV file (3+ seconds recommended, 24 kHz mono preferred).</param>
+    /// <returns>Speaker embedding float array (1024 dimensions).</returns>
+    public float[] ExtractSpeakerEmbedding(string referenceAudioPath)
+    {
+        return _speakerEncoder.EncodeFromWav(referenceAudioPath);
+    }
+
+    /// <summary>
+    /// Synthesize speech with a cloned voice from reference audio.
+    /// </summary>
+    /// <param name="text">Text to synthesize.</param>
+    /// <param name="referenceAudioPath">Path to a reference WAV file for voice cloning.</param>
+    /// <param name="outputPath">Path to save the output WAV file.</param>
+    /// <param name="language">Language code (e.g., "english", "chinese", "auto").</param>
+    /// <param name="progress">Optional progress callback.</param>
+    public async Task SynthesizeAsync(string text, string referenceAudioPath, string outputPath,
+                                      string language = "auto", IProgress<string>? progress = null)
+    {
+        // Step 1: Extract speaker embedding from reference audio
+        progress?.Report("Extracting speaker embedding from reference audio...");
+        var speakerEmbedding = ExtractSpeakerEmbedding(referenceAudioPath);
+        progress?.Report($"Speaker embedding extracted ({speakerEmbedding.Length} dimensions)");
+
+        // Step 2: Synthesize using the extracted embedding
+        await SynthesizeWithEmbeddingAsync(text, speakerEmbedding, outputPath, language, progress);
+    }
+
+    /// <summary>
+    /// Synthesize speech using a pre-extracted speaker embedding.
+    /// Use this when synthesizing multiple utterances with the same cloned voice
+    /// to avoid re-encoding the reference audio each time.
+    /// </summary>
+    public async Task SynthesizeWithEmbeddingAsync(string text, float[] speakerEmbedding, string outputPath,
+                                                    string language = "auto", IProgress<string>? progress = null)
+    {
+        // Build prompt tokens (use "default" speaker — embedding replaces speaker identity)
+        var tokenIds = _tokenizer.BuildCustomVoicePrompt(text, "default", language, instruct: null);
+        progress?.Report($"Tokenized input ({tokenIds.Length} tokens)");
+        Console.WriteLine($"Generating speech ({tokenIds.Length} input tokens)...");
+
+        // Generate audio codes via LM
+        // Note: For the Base model, the speaker identity comes from the ECAPA-TDNN embedding,
+        // not from the speaker name. We pass "default" as a placeholder.
+        progress?.Report("Running language model inference...");
+        var codes = _languageModel.Generate(tokenIds, "default", language);
+
+        int timesteps = codes.GetLength(2);
+        progress?.Report($"Generated {timesteps} audio frames");
+        Console.WriteLine($"Generated {timesteps} audio frames");
+
+        // Decode to waveform via vocoder
+        progress?.Report("Decoding waveform via vocoder...");
+        var waveform = _vocoder.Decode(codes);
+
+        // Write WAV file
+        progress?.Report("Writing WAV file...");
+        await Task.Run(() => WavWriter.Write(outputPath, waveform, sampleRate: 24000));
+
+        var duration = waveform.Length / 24000.0;
+        progress?.Report($"Saved {Path.GetFileName(outputPath)} ({waveform.Length} samples, {duration:F2}s)");
+        Console.WriteLine($"Saved {outputPath} ({waveform.Length} samples, {duration:F2}s)");
+    }
+
+    /// <summary>
+    /// Creates a VoiceClonePipeline, automatically downloading Base model files if missing.
+    /// </summary>
+    public static async Task<VoiceClonePipeline> CreateAsync(
+        string? modelDir = null,
+        string repoId = VoiceCloningDownloader.DefaultRepoId,
+        IProgress<string>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        modelDir ??= VoiceCloningDownloader.DefaultModelDir;
+        if (!VoiceCloningDownloader.IsModelDownloaded(modelDir))
+        {
+            progress?.Report("Base model files not found — downloading from HuggingFace...");
+            var downloadProgress = progress != null
+                ? new Progress<ModelDownloadProgress>(p => progress.Report(p.Message))
+                : null;
+            await VoiceCloningDownloader.DownloadModelAsync(modelDir, repoId, downloadProgress, cancellationToken);
+            progress?.Report("Model download complete.");
+        }
+        return new VoiceClonePipeline(modelDir);
+    }
+
+    public void Dispose()
+    {
+        _tokenizer.Dispose();
+        _embeddings.Dispose();
+        _languageModel.Dispose();
+        _vocoder.Dispose();
+        _speakerEncoder.Dispose();
+    }
+}

--- a/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceCloningDownloader.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceCloningDownloader.cs
@@ -1,0 +1,123 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using ElBruno.QwenTTS.Pipeline;
+
+namespace ElBruno.QwenTTS.VoiceCloning.Pipeline;
+
+/// <summary>
+/// Downloads Qwen3-TTS Base model ONNX files (including speaker encoder)
+/// from a HuggingFace repository.
+/// </summary>
+public sealed class VoiceCloningDownloader
+{
+    public const string DefaultRepoId = "elbruno/Qwen3-TTS-12Hz-0.6B-Base-ONNX";
+    private const string HfResolveBase = "https://huggingface.co";
+
+    /// <summary>
+    /// Default model directory for voice cloning models.
+    /// Stored alongside the CustomVoice models under the shared ElBruno folder.
+    /// </summary>
+    public static string DefaultModelDir =>
+        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                     "ElBruno", "QwenTTS-Base");
+
+    private static readonly string[] ExpectedFiles =
+    [
+        "speaker_encoder.onnx",
+        "speaker_encoder.onnx.data",
+        "talker_prefill.onnx",
+        "talker_prefill.onnx.data",
+        "talker_decode.onnx",
+        "talker_decode.onnx.data",
+        "code_predictor.onnx",
+        "vocoder.onnx",
+        "embeddings/config.json",
+        "embeddings/talker_codec_embedding.npy",
+        "embeddings/text_embedding.npy",
+        "embeddings/text_projection_fc1_weight.npy",
+        "embeddings/text_projection_fc1_bias.npy",
+        "embeddings/text_projection_fc2_weight.npy",
+        "embeddings/text_projection_fc2_bias.npy",
+        "embeddings/codec_head_weight.npy",
+        "embeddings/speaker_ids.json",
+        "tokenizer/vocab.json",
+        "tokenizer/merges.txt",
+        .. Enumerable.Range(0, 15).Select(i => $"embeddings/cp_codec_embedding_{i}.npy").ToArray()
+    ];
+
+    /// <summary>
+    /// Returns true if the model directory contains all required files for voice cloning.
+    /// </summary>
+    public static bool IsModelDownloaded(string? modelDir = null)
+    {
+        modelDir ??= DefaultModelDir;
+        return ExpectedFiles.All(f =>
+            File.Exists(Path.Combine(modelDir, f.Replace('/', Path.DirectorySeparatorChar))));
+    }
+
+    /// <summary>
+    /// Downloads all required model files from HuggingFace.
+    /// </summary>
+    public static async Task DownloadModelAsync(
+        string? modelDir = null,
+        string repoId = DefaultRepoId,
+        IProgress<ModelDownloadProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        modelDir ??= DefaultModelDir;
+        Directory.CreateDirectory(modelDir);
+
+        using var http = new HttpClient();
+        http.DefaultRequestHeaders.UserAgent.ParseAdd("ElBruno.QwenTTS.VoiceCloning/1.0");
+
+        int totalFiles = ExpectedFiles.Length;
+        int currentFile = 0;
+
+        foreach (var relativePath in ExpectedFiles)
+        {
+            currentFile++;
+            var localPath = Path.Combine(modelDir, relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+            if (File.Exists(localPath))
+            {
+                progress?.Report(new ModelDownloadProgress(
+                    currentFile, totalFiles, relativePath,
+                    $"[{currentFile}/{totalFiles}] {relativePath} (cached)", 0, 0));
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(localPath)!);
+
+            var url = $"{HfResolveBase}/{repoId}/resolve/main/{relativePath}";
+            progress?.Report(new ModelDownloadProgress(
+                currentFile, totalFiles, relativePath,
+                $"[{currentFile}/{totalFiles}] Downloading {relativePath}...", 0, 0));
+
+            using var response = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var totalBytes = response.Content.Headers.ContentLength ?? 0;
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            await using var fileStream = File.Create(localPath);
+
+            var buffer = new byte[81920];
+            long downloaded = 0;
+            int bytesRead;
+
+            while ((bytesRead = await contentStream.ReadAsync(buffer, cancellationToken)) > 0)
+            {
+                await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
+                downloaded += bytesRead;
+
+                progress?.Report(new ModelDownloadProgress(
+                    currentFile, totalFiles, relativePath,
+                    $"[{currentFile}/{totalFiles}] {relativePath} ({downloaded:N0}/{totalBytes:N0} bytes)",
+                    downloaded, totalBytes));
+            }
+        }
+
+        progress?.Report(new ModelDownloadProgress(
+            totalFiles, totalFiles, "",
+            "All model files downloaded.", 0, 0));
+    }
+}


### PR DESCRIPTION
## Summary

Adds voice cloning support using the Qwen3-TTS Base model with ECAPA-TDNN speaker encoder.

### New: `ElBruno.QwenTTS.VoiceCloning` library

A separate NuGet package that extends Core with voice cloning:

- **`VoiceClonePipeline`** — orchestrates: reference WAV → mel-spectrogram → speaker encoder → LM → vocoder → output WAV
- **`SpeakerEncoder`** — wraps `speaker_encoder.onnx` (ECAPA-TDNN, 1024-dim embeddings)
- **`MelSpectrogram`** — FFT + mel-filterbank DSP (24 kHz, 128 mel bins)
- **`VoiceCloningDownloader`** — auto-downloads Base model from HuggingFace

### Python export pipeline

- `export_speaker_encoder.py` — exports ECAPA-TDNN to ONNX (cosine similarity 1.0)
- Updated `download_models.py` with `--model base|customvoice|all`
- Base model ONNX files uploaded to [elbruno/Qwen3-TTS-12Hz-0.6B-Base-ONNX](https://huggingface.co/elbruno/Qwen3-TTS-12Hz-0.6B-Base-ONNX)

### Tests

- 9 new tests covering mel-spectrogram DSP, downloader, speaker encoder, and pipeline
- All 28 tests pass (19 Core + 9 VoiceCloning)

### Docs

- `docs/voice-cloning.md` — full usage guide
- Updated `README.md` with voice cloning section

### Architecture Decision

Created as a **separate library** (not added to Core) because:
1. Voice cloning is orthogonal to standard TTS
2. 80%+ of users don't need the speaker encoder overhead
3. Core has no interfaces — adding VC would force breaking API changes
4. Independent versioning