### PR TITLE
Add GPU acceleration support via SessionOptions injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **GPU Acceleration** — configurable `SessionOptions` injection for CUDA and DirectML support
+  - `TtsPipeline` and `VoiceClonePipeline` accept optional `Func<SessionOptions>?` parameter
+  - `OrtSessionHelper` static class with `CreateCpuOptions()`, `CreateCudaOptions()`, `CreateDirectMlOptions()`
+  - All ONNX sessions (LanguageModel, Vocoder, SpeakerEncoder) respect the configured execution provider
+  - Default behavior unchanged (CPU with full graph optimization)
+  - [GPU Acceleration docs](docs/gpu-acceleration.md)
+
 ## [1.0.0] - 2026-02-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Pre-exported ONNX models are hosted on HuggingFace:
 - **Automatic Model Download** — Models download from HuggingFace on first run (~5.5 GB)
 - **Multi-Speaker** — 9 built-in voices: ryan, serena, vivian, aiden, eric, dylan, uncle_fu, ono_anna, sohee
 - **Voice Cloning** — Clone any voice from a 3-second audio sample ([docs](docs/voice-cloning.md))
+- **GPU Acceleration** — Optional CUDA or DirectML support via SessionOptions injection ([docs](docs/gpu-acceleration.md))
 - **Multi-Language** — English, Spanish, Chinese, Japanese, Korean
 - **Voice Control** — Instruction-based style (e.g., "speak with excitement")
 - **Shared Model Cache** — Models stored once in `%LOCALAPPDATA%/ElBruno/QwenTTS`, shared across all apps
@@ -113,6 +114,8 @@ Open [http://localhost:5153](http://localhost:5153) — type text or upload file
 | [Web App](docs/web-app.md) | Blazor web UI for speech generation |
 | [Architecture](docs/architecture.md) | Pipeline design, model components, project structure |
 | [Exporting Models](docs/exporting-models.md) | Re-exporting ONNX models from PyTorch weights |
+| [Voice Cloning](docs/voice-cloning.md) | Clone any voice from a 3-second reference audio |
+| [GPU Acceleration](docs/gpu-acceleration.md) | CUDA, DirectML, and CPU configuration |
 | [Troubleshooting](docs/troubleshooting.md) | Common issues and fixes |
 | [Detailed Architecture](python/ARCHITECTURE.md) | Full tensor shapes, KV-cache, codebook structure |
 | [Changelog](CHANGELOG.md) | Versioned summary of notable changes |

--- a/docs/gpu-acceleration.md
+++ b/docs/gpu-acceleration.md
@@ -1,0 +1,115 @@
+# GPU Acceleration
+
+ElBruno.QwenTTS supports GPU acceleration through ONNX Runtime execution providers. The same ONNX models work on both CPU and GPU — no re-export needed.
+
+## Quick Start
+
+### 1. Choose your GPU backend
+
+| Package | Backend | Supported GPUs | OS | Prerequisites |
+|---------|---------|---------------|-----|--------------|
+| `Microsoft.ML.OnnxRuntime` | CPU | — | All | None |
+| `Microsoft.ML.OnnxRuntime.Gpu` | CUDA | NVIDIA | Win/Linux | CUDA Toolkit + cuDNN |
+| `Microsoft.ML.OnnxRuntime.DirectML` | DirectML | NVIDIA, AMD, Intel | Windows 10/11 | None |
+
+> **Important:** These packages are **mutually exclusive** — only reference **one** in your project.
+
+### 2. Swap the NuGet package
+
+Replace the CPU package with your GPU backend:
+
+```xml
+<!-- In your .csproj — choose ONE: -->
+
+<!-- CPU (default) -->
+<PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.24.2" />
+
+<!-- NVIDIA GPU via CUDA -->
+<PackageReference Include="Microsoft.ML.OnnxRuntime.Gpu" Version="1.24.2" />
+
+<!-- Any GPU via DirectML (Windows only) -->
+<PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.24.2" />
+```
+
+### 3. Configure SessionOptions
+
+Pass a `sessionOptionsFactory` to the pipeline constructor or factory:
+
+```csharp
+using ElBruno.QwenTTS.Pipeline;
+using Microsoft.ML.OnnxRuntime;
+
+// CPU (default — no changes needed)
+var tts = await TtsPipeline.CreateAsync();
+
+// CUDA GPU
+var tts = await TtsPipeline.CreateAsync(
+    sessionOptionsFactory: OrtSessionHelper.CreateCudaOptions);
+
+// DirectML GPU (Windows)
+var tts = await TtsPipeline.CreateAsync(
+    sessionOptionsFactory: OrtSessionHelper.CreateDirectMlOptions);
+
+// Custom configuration
+var tts = await TtsPipeline.CreateAsync(
+    sessionOptionsFactory: () =>
+    {
+        var opts = new SessionOptions();
+        opts.AppendExecutionProvider_CUDA(deviceId: 1); // second GPU
+        opts.AppendExecutionProvider_CPU(); // CPU fallback
+        return opts;
+    });
+```
+
+### Voice Cloning with GPU
+
+The same pattern works for `VoiceClonePipeline`:
+
+```csharp
+using ElBruno.QwenTTS.VoiceCloning.Pipeline;
+
+var cloner = await VoiceClonePipeline.CreateAsync(
+    sessionOptionsFactory: OrtSessionHelper.CreateCudaOptions);
+```
+
+## Helper Methods
+
+`OrtSessionHelper` provides convenience methods for common configurations:
+
+| Method | Description |
+|--------|-------------|
+| `CreateCpuOptions()` | CPU with max graph optimization (default) |
+| `CreateCudaOptions(deviceId)` | CUDA provider + CPU fallback |
+| `CreateDirectMlOptions(deviceId)` | DirectML provider + CPU fallback |
+
+All methods set `GraphOptimizationLevel.ORT_ENABLE_ALL` and include CPU as a fallback provider.
+
+## How It Works
+
+- `TtsPipeline` and `VoiceClonePipeline` accept an optional `Func<SessionOptions>?` parameter
+- This factory is called once per ONNX session (LanguageModel creates 3, Vocoder creates 1, SpeakerEncoder creates 1)
+- When `null` (default), sessions use CPU with full graph optimization
+- The factory pattern lets you configure any execution provider ONNX Runtime supports
+
+## Performance Notes
+
+- **CUDA** offers the best performance for NVIDIA GPUs but requires driver/toolkit installation
+- **DirectML** works out-of-the-box on Windows with any GPU vendor
+- The language model (3 sessions: prefill, decode, code_predictor) benefits most from GPU acceleration
+- The vocoder is relatively lightweight and may not see as much speedup
+- First inference is slower due to GPU kernel compilation; subsequent calls are faster
+
+## Troubleshooting
+
+### "CUDA execution provider is not enabled"
+Install `Microsoft.ML.OnnxRuntime.Gpu` instead of `Microsoft.ML.OnnxRuntime`, and ensure CUDA Toolkit + cuDNN are installed.
+
+### "DML execution provider is not enabled"
+Install `Microsoft.ML.OnnxRuntime.DirectML` instead of `Microsoft.ML.OnnxRuntime`.
+
+### Mixed package errors
+Only one ORT package can be referenced per project. Remove conflicting packages:
+```bash
+dotnet remove package Microsoft.ML.OnnxRuntime
+dotnet add package Microsoft.ML.OnnxRuntime.Gpu
+```

--- a/src/ElBruno.QwenTTS.Core/Models/LanguageModel.cs
+++ b/src/ElBruno.QwenTTS.Core/Models/LanguageModel.cs
@@ -15,26 +15,28 @@ public sealed class LanguageModel : IDisposable
     private InferenceSession? _cpSession;
     private readonly EmbeddingStore _embeddings;
     private readonly string _modelDir;
+    private readonly Func<SessionOptions> _sessionOptionsFactory;
 
-    public LanguageModel(string modelDir, EmbeddingStore embeddings)
+    public LanguageModel(string modelDir, EmbeddingStore embeddings, Func<SessionOptions>? sessionOptionsFactory = null)
     {
         _embeddings = embeddings;
         _modelDir = modelDir;
+        _sessionOptionsFactory = sessionOptionsFactory ?? CreateDefaultOptions;
     }
 
-    private static SessionOptions CreateOptions() => new()
+    private static SessionOptions CreateDefaultOptions() => new()
     {
         GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
     };
 
     private InferenceSession GetPrefillSession()
-        => _prefillSession ??= new InferenceSession(Path.Combine(_modelDir, "talker_prefill.onnx"), CreateOptions());
+        => _prefillSession ??= new InferenceSession(Path.Combine(_modelDir, "talker_prefill.onnx"), _sessionOptionsFactory());
 
     private InferenceSession GetDecodeSession()
-        => _decodeSession ??= new InferenceSession(Path.Combine(_modelDir, "talker_decode.onnx"), CreateOptions());
+        => _decodeSession ??= new InferenceSession(Path.Combine(_modelDir, "talker_decode.onnx"), _sessionOptionsFactory());
 
     private InferenceSession GetCpSession()
-        => _cpSession ??= new InferenceSession(Path.Combine(_modelDir, "code_predictor.onnx"), CreateOptions());
+        => _cpSession ??= new InferenceSession(Path.Combine(_modelDir, "code_predictor.onnx"), _sessionOptionsFactory());
 
     public long[,,] Generate(int[] tokenIds, string speaker, string language,
                              int maxNewTokens = 2048, float temperature = 0.9f,

--- a/src/ElBruno.QwenTTS.Core/Models/Vocoder.cs
+++ b/src/ElBruno.QwenTTS.Core/Models/Vocoder.cs
@@ -13,26 +13,31 @@ public sealed class Vocoder : IDisposable
     private InferenceSession? _session;
     private string? _inputName;
     private readonly string _modelPath;
+    private readonly Func<SessionOptions> _sessionOptionsFactory;
 
     public int SampleRate => 24000;
 
     /// <summary>
     /// Creates a vocoder wrapper. Session is loaded lazily on first Decode call.
     /// </summary>
-    public Vocoder(string modelPath)
+    /// <param name="modelPath">Path to the vocoder ONNX model.</param>
+    /// <param name="sessionOptionsFactory">Optional factory for ONNX Runtime session options (e.g., for GPU acceleration).</param>
+    public Vocoder(string modelPath, Func<SessionOptions>? sessionOptionsFactory = null)
     {
         _modelPath = modelPath;
+        _sessionOptionsFactory = sessionOptionsFactory ?? CreateDefaultOptions;
     }
+
+    private static SessionOptions CreateDefaultOptions() => new()
+    {
+        GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
+    };
 
     private InferenceSession GetSession()
     {
         if (_session is null)
         {
-            var options = new SessionOptions
-            {
-                GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
-            };
-            _session = new InferenceSession(_modelPath, options);
+            _session = new InferenceSession(_modelPath, _sessionOptionsFactory());
             _inputName = _session.InputMetadata.Keys.FirstOrDefault() ?? "codes";
         }
         return _session;

--- a/src/ElBruno.QwenTTS.Core/Pipeline/OrtSessionHelper.cs
+++ b/src/ElBruno.QwenTTS.Core/Pipeline/OrtSessionHelper.cs
@@ -1,0 +1,62 @@
+using Microsoft.ML.OnnxRuntime;
+
+namespace ElBruno.QwenTTS.Pipeline;
+
+/// <summary>
+/// Helper methods for creating ONNX Runtime SessionOptions with different execution providers.
+/// 
+/// Usage: Pass the desired factory method to TtsPipeline or VoiceClonePipeline constructors.
+/// The consumer must reference the appropriate NuGet package for their chosen GPU backend:
+///   - CPU (default): Microsoft.ML.OnnxRuntime
+///   - CUDA: Microsoft.ML.OnnxRuntime.Gpu
+///   - DirectML: Microsoft.ML.OnnxRuntime.DirectML
+/// 
+/// Note: GPU NuGet packages are mutually exclusive — only one can be referenced per project.
+/// </summary>
+public static class OrtSessionHelper
+{
+    /// <summary>
+    /// Creates SessionOptions for CPU execution (default behavior).
+    /// </summary>
+    public static SessionOptions CreateCpuOptions()
+    {
+        return new SessionOptions
+        {
+            GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
+        };
+    }
+
+    /// <summary>
+    /// Creates SessionOptions for CUDA GPU execution.
+    /// Requires the <c>Microsoft.ML.OnnxRuntime.Gpu</c> NuGet package and CUDA Toolkit + cuDNN installed.
+    /// Falls back to CPU if CUDA is unavailable.
+    /// </summary>
+    /// <param name="deviceId">GPU device ID (default: 0).</param>
+    public static SessionOptions CreateCudaOptions(int deviceId = 0)
+    {
+        var options = new SessionOptions
+        {
+            GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
+        };
+        options.AppendExecutionProvider_CUDA(deviceId);
+        options.AppendExecutionProvider_CPU();
+        return options;
+    }
+
+    /// <summary>
+    /// Creates SessionOptions for DirectML GPU execution (Windows 10/11 — supports NVIDIA, AMD, and Intel GPUs).
+    /// Requires the <c>Microsoft.ML.OnnxRuntime.DirectML</c> NuGet package.
+    /// Falls back to CPU if DirectML is unavailable.
+    /// </summary>
+    /// <param name="deviceId">GPU device ID (default: 0).</param>
+    public static SessionOptions CreateDirectMlOptions(int deviceId = 0)
+    {
+        var options = new SessionOptions
+        {
+            GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
+        };
+        options.AppendExecutionProvider_DML(deviceId);
+        options.AppendExecutionProvider_CPU();
+        return options;
+    }
+}

--- a/src/ElBruno.QwenTTS.Core/Pipeline/TtsPipeline.cs
+++ b/src/ElBruno.QwenTTS.Core/Pipeline/TtsPipeline.cs
@@ -1,3 +1,4 @@
+using Microsoft.ML.OnnxRuntime;
 using ElBruno.QwenTTS.Audio;
 using ElBruno.QwenTTS.Models;
 
@@ -13,7 +14,12 @@ public sealed class TtsPipeline : IDisposable
     private readonly Vocoder _vocoder;
     private readonly EmbeddingStore _embeddings;
 
-    public TtsPipeline(string modelDir)
+    /// <summary>
+    /// Creates a TtsPipeline from a local model directory.
+    /// </summary>
+    /// <param name="modelDir">Directory containing ONNX models, embeddings, and tokenizer.</param>
+    /// <param name="sessionOptionsFactory">Optional factory for ONNX Runtime session options (e.g., for GPU acceleration). When null, uses CPU with max optimization.</param>
+    public TtsPipeline(string modelDir, Func<SessionOptions>? sessionOptionsFactory = null)
     {
         var tokenizerDir = Path.Combine(modelDir, "tokenizer");
         var embeddingsDir = Path.Combine(modelDir, "embeddings");
@@ -21,8 +27,8 @@ public sealed class TtsPipeline : IDisposable
 
         _tokenizer = new TextTokenizer(tokenizerDir);
         _embeddings = new EmbeddingStore(embeddingsDir, configPath);
-        _languageModel = new LanguageModel(modelDir, _embeddings);
-        _vocoder = new Vocoder(Path.Combine(modelDir, "vocoder.onnx"));
+        _languageModel = new LanguageModel(modelDir, _embeddings, sessionOptionsFactory);
+        _vocoder = new Vocoder(Path.Combine(modelDir, "vocoder.onnx"), sessionOptionsFactory);
     }
 
     /// <summary>Available speaker names from the model.</summary>
@@ -65,11 +71,13 @@ public sealed class TtsPipeline : IDisposable
     /// <param name="modelDir">Directory to store/load model files. Defaults to shared location in LocalAppData.</param>
     /// <param name="repoId">HuggingFace repository ID (default: elbruno/Qwen3-TTS-12Hz-0.6B-CustomVoice-ONNX).</param>
     /// <param name="progress">Optional progress callback for download status.</param>
+    /// <param name="sessionOptionsFactory">Optional factory for ONNX Runtime session options (e.g., for GPU acceleration).</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task<TtsPipeline> CreateAsync(
         string? modelDir = null,
         string repoId = ModelDownloader.DefaultRepoId,
         IProgress<string>? progress = null,
+        Func<SessionOptions>? sessionOptionsFactory = null,
         CancellationToken cancellationToken = default)
     {
         modelDir ??= ModelDownloader.DefaultModelDir;
@@ -82,7 +90,7 @@ public sealed class TtsPipeline : IDisposable
             await ModelDownloader.DownloadModelAsync(modelDir, repoId, downloadProgress, cancellationToken);
             progress?.Report("Model download complete.");
         }
-        return new TtsPipeline(modelDir);
+        return new TtsPipeline(modelDir, sessionOptionsFactory);
     }
 
     /// <summary>
@@ -92,12 +100,13 @@ public sealed class TtsPipeline : IDisposable
         string? modelDir,
         IProgress<ModelDownloadProgress> downloadProgress,
         string repoId = ModelDownloader.DefaultRepoId,
+        Func<SessionOptions>? sessionOptionsFactory = null,
         CancellationToken cancellationToken = default)
     {
         modelDir ??= ModelDownloader.DefaultModelDir;
         if (!ModelDownloader.IsModelDownloaded(modelDir))
             await ModelDownloader.DownloadModelAsync(modelDir, repoId, downloadProgress, cancellationToken);
-        return new TtsPipeline(modelDir);
+        return new TtsPipeline(modelDir, sessionOptionsFactory);
     }
 
     public void Dispose()

--- a/src/ElBruno.QwenTTS.VoiceCloning/Models/SpeakerEncoder.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Models/SpeakerEncoder.cs
@@ -13,6 +13,7 @@ public sealed class SpeakerEncoder : IDisposable
 {
     private InferenceSession? _session;
     private readonly string _modelPath;
+    private readonly Func<SessionOptions> _sessionOptionsFactory;
 
     /// <summary>Embedding dimension (1024 for ECAPA-TDNN in Qwen3-TTS).</summary>
     public int EmbeddingDim => 1024;
@@ -20,20 +21,22 @@ public sealed class SpeakerEncoder : IDisposable
     /// <summary>Expected number of mel bins.</summary>
     public int MelDim => 128;
 
-    public SpeakerEncoder(string modelPath)
+    public SpeakerEncoder(string modelPath, Func<SessionOptions>? sessionOptionsFactory = null)
     {
         _modelPath = modelPath;
+        _sessionOptionsFactory = sessionOptionsFactory ?? CreateDefaultOptions;
     }
+
+    private static SessionOptions CreateDefaultOptions() => new()
+    {
+        GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
+    };
 
     private InferenceSession GetSession()
     {
         if (_session is null)
         {
-            var options = new SessionOptions
-            {
-                GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
-            };
-            _session = new InferenceSession(_modelPath, options);
+            _session = new InferenceSession(_modelPath, _sessionOptionsFactory());
         }
         return _session;
     }

--- a/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceClonePipeline.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceClonePipeline.cs
@@ -1,3 +1,4 @@
+using Microsoft.ML.OnnxRuntime;
 using ElBruno.QwenTTS.Audio;
 using ElBruno.QwenTTS.Models;
 using ElBruno.QwenTTS.Pipeline;
@@ -20,7 +21,12 @@ public sealed class VoiceClonePipeline : IDisposable
     private readonly EmbeddingStore _embeddings;
     private readonly SpeakerEncoder _speakerEncoder;
 
-    public VoiceClonePipeline(string modelDir)
+    /// <summary>
+    /// Creates a VoiceClonePipeline from a local model directory.
+    /// </summary>
+    /// <param name="modelDir">Directory containing ONNX models, embeddings, and tokenizer.</param>
+    /// <param name="sessionOptionsFactory">Optional factory for ONNX Runtime session options (e.g., for GPU acceleration). When null, uses CPU with max optimization.</param>
+    public VoiceClonePipeline(string modelDir, Func<SessionOptions>? sessionOptionsFactory = null)
     {
         var tokenizerDir = Path.Combine(modelDir, "tokenizer");
         var embeddingsDir = Path.Combine(modelDir, "embeddings");
@@ -34,9 +40,9 @@ public sealed class VoiceClonePipeline : IDisposable
 
         _tokenizer = new TextTokenizer(tokenizerDir);
         _embeddings = new EmbeddingStore(embeddingsDir, configPath);
-        _languageModel = new LanguageModel(modelDir, _embeddings);
-        _vocoder = new Vocoder(Path.Combine(modelDir, "vocoder.onnx"));
-        _speakerEncoder = new SpeakerEncoder(speakerEncoderPath);
+        _languageModel = new LanguageModel(modelDir, _embeddings, sessionOptionsFactory);
+        _vocoder = new Vocoder(Path.Combine(modelDir, "vocoder.onnx"), sessionOptionsFactory);
+        _speakerEncoder = new SpeakerEncoder(speakerEncoderPath, sessionOptionsFactory);
     }
 
     /// <summary>
@@ -110,10 +116,16 @@ public sealed class VoiceClonePipeline : IDisposable
     /// <summary>
     /// Creates a VoiceClonePipeline, automatically downloading Base model files if missing.
     /// </summary>
+    /// <param name="modelDir">Directory to store/load model files. Defaults to shared location in LocalAppData.</param>
+    /// <param name="repoId">HuggingFace repository ID.</param>
+    /// <param name="progress">Optional progress callback for download status.</param>
+    /// <param name="sessionOptionsFactory">Optional factory for ONNX Runtime session options (e.g., for GPU acceleration).</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     public static async Task<VoiceClonePipeline> CreateAsync(
         string? modelDir = null,
         string repoId = VoiceCloningDownloader.DefaultRepoId,
         IProgress<string>? progress = null,
+        Func<SessionOptions>? sessionOptionsFactory = null,
         CancellationToken cancellationToken = default)
     {
         modelDir ??= VoiceCloningDownloader.DefaultModelDir;
@@ -126,7 +138,7 @@ public sealed class VoiceClonePipeline : IDisposable
             await VoiceCloningDownloader.DownloadModelAsync(modelDir, repoId, downloadProgress, cancellationToken);
             progress?.Report("Model download complete.");
         }
-        return new VoiceClonePipeline(modelDir);
+        return new VoiceClonePipeline(modelDir, sessionOptionsFactory);
     }
 
     public void Dispose()


### PR DESCRIPTION
Adds configurable GPU acceleration to Core and VoiceCloning via Func<SessionOptions>? parameter. Includes OrtSessionHelper utility and docs/gpu-acceleration.md. All 28 tests pass. No breaking changes.