### PR TITLE
Fix static file serving for runtime-generated audio files

### DIFF
--- a/src/ElBruno.QwenTTS.Web/Program.cs
+++ b/src/ElBruno.QwenTTS.Web/Program.cs
@@ -1,5 +1,6 @@
 using ElBruno.QwenTTS.Web.Components;
 using ElBruno.QwenTTS.Web.Services;
+using Microsoft.Extensions.FileProviders;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -23,8 +24,27 @@ if (!app.Environment.IsDevelopment())
 }
 app.UseAntiforgery();
 
+// Serve runtime-generated files (WAV audio, references) via dedicated static file providers.
+// These are created at runtime and not in the compile-time manifest, so they must be
+// served by UseStaticFiles before MapStaticAssets to avoid manifest warnings.
+var webRootPath = app.Environment.WebRootPath;
+var generatedDir = Path.Combine(webRootPath, "generated");
+var referencesDir = Path.Combine(webRootPath, "references");
+Directory.CreateDirectory(generatedDir);
+Directory.CreateDirectory(referencesDir);
+
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider(generatedDir),
+    RequestPath = "/generated"
+});
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider(referencesDir),
+    RequestPath = "/references"
+});
+
 app.MapStaticAssets();
-app.UseStaticFiles();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 


### PR DESCRIPTION
Runtime-created files triggered MapStaticAssets manifest warnings. Fix: dedicated PhysicalFileProvider middleware for /generated and /references.