### PR TITLE
fix: handle empty speaker_ids.json in Base model voice cloning

### DIFF
--- a/src/ElBruno.QwenTTS.Core/Models/LanguageModel.cs
+++ b/src/ElBruno.QwenTTS.Core/Models/LanguageModel.cs
@@ -43,8 +43,20 @@ internal sealed class LanguageModel : IDisposable
                              int topK = 50, float topP = 1.0f,
                              float repetitionPenalty = 1.05f)
     {
-        var cfg = _embeddings.Config;
         var speakerId = _embeddings.GetSpeakerId(speaker.ToLowerInvariant());
+        return GenerateWithSpeakerId(tokenIds, speakerId, language, maxNewTokens, temperature, topK, topP, repetitionPenalty);
+    }
+
+    /// <summary>
+    /// Generate audio codes using an explicit speaker ID. Pass -1 to omit the speaker token
+    /// from the codec prefix (used by the Base model where voice identity comes from a speaker embedding).
+    /// </summary>
+    public long[,,] GenerateWithSpeakerId(int[] tokenIds, int speakerId, string language,
+                             int maxNewTokens = 2048, float temperature = 0.9f,
+                             int topK = 50, float topP = 1.0f,
+                             float repetitionPenalty = 1.05f)
+    {
+        var cfg = _embeddings.Config;
         
         // Build prefill embedding
         var (inputsEmbeds, trailingTextHidden) = BuildPrefillEmbedding(tokenIds, speakerId, language, cfg);
@@ -264,7 +276,9 @@ internal sealed class LanguageModel : IDisposable
             codecPrefix.Add(cfg.talker.codec_think_eos_id);
         }
         
-        codecPrefix.Add(speakerId);
+        // Speaker token: only add when speakerId >= 0 (Base model has no speakers)
+        if (speakerId >= 0)
+            codecPrefix.Add(speakerId);
         codecPrefix.Add(cfg.talker.codec_pad_id);
         codecPrefix.Add(cfg.talker.codec_bos_id);
 

--- a/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceClonePipeline.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceClonePipeline.cs
@@ -85,16 +85,20 @@ public sealed class VoiceClonePipeline : IDisposable
     public async Task SynthesizeWithEmbeddingAsync(string text, float[] speakerEmbedding, string outputPath,
                                                     string language = "auto", IProgress<string>? progress = null)
     {
-        // Use first available speaker as placeholder — voice identity comes from the ECAPA-TDNN embedding
-        var placeholderSpeaker = _embeddings.GetAvailableSpeakers().First();
+        // For the Base model, speaker_ids.json is empty — voice identity comes from the ECAPA-TDNN embedding.
+        // Use speakerId = -1 to skip the speaker token in the codec prefix.
+        var speakers = _embeddings.GetAvailableSpeakers();
+        var hasSpeakers = speakers.Count > 0;
+        var placeholderSpeaker = hasSpeakers ? speakers.First() : "none";
+        var speakerId = hasSpeakers ? _embeddings.GetSpeakerId(placeholderSpeaker) : -1;
 
         var tokenIds = _tokenizer.BuildCustomVoicePrompt(text, placeholderSpeaker, language, instruct: null);
         progress?.Report($"Tokenized input ({tokenIds.Length} tokens)");
         Console.WriteLine($"Generating speech ({tokenIds.Length} input tokens)...");
 
-        // Generate audio codes via LM
+        // Generate audio codes via LM (speakerId = -1 skips the speaker token)
         progress?.Report("Running language model inference...");
-        var codes = _languageModel.Generate(tokenIds, placeholderSpeaker, language);
+        var codes = _languageModel.GenerateWithSpeakerId(tokenIds, speakerId, language);
 
         int timesteps = codes.GetLength(2);
         progress?.Report($"Generated {timesteps} audio frames");


### PR DESCRIPTION
The Base model's `speaker_ids.json` is `{}` (empty) because voice identity comes from the ECAPA-TDNN speaker embedding, not from preset speaker tokens. This caused `Sequence contains no elements` when calling `.First()` on an empty speaker collection.

**Changes:**
- Add `LanguageModel.GenerateWithSpeakerId()` overload that accepts an explicit `int speakerId`, bypassing name lookup
- Skip speaker token in codec prefix when `speakerId = -1`
- `VoiceClonePipeline` detects empty speakers and uses `speakerId = -1`

All 28 tests pass.