### PR TITLE
fix: inject ECAPA-TDNN speaker embedding into LM for voice cloning

### DIFF
--- a/src/ElBruno.QwenTTS.Core/Models/LanguageModel.cs
+++ b/src/ElBruno.QwenTTS.Core/Models/LanguageModel.cs
@@ -56,10 +56,34 @@ internal sealed class LanguageModel : IDisposable
                              int topK = 50, float topP = 1.0f,
                              float repetitionPenalty = 1.05f)
     {
+        return GenerateInternal(tokenIds, speakerId, language, speakerEmbedding: null,
+            maxNewTokens, temperature, topK, topP, repetitionPenalty);
+    }
+
+    /// <summary>
+    /// Generate audio codes using a speaker embedding vector (e.g., from ECAPA-TDNN).
+    /// The 1024-dim embedding is injected at the speaker position in the codec prefix,
+    /// replacing the preset speaker token lookup. Used for voice cloning with the Base model.
+    /// </summary>
+    public long[,,] GenerateWithSpeakerEmbedding(int[] tokenIds, float[] speakerEmbedding, string language,
+                             int maxNewTokens = 2048, float temperature = 0.9f,
+                             int topK = 50, float topP = 1.0f,
+                             float repetitionPenalty = 1.05f)
+    {
+        return GenerateInternal(tokenIds, speakerId: -1, language, speakerEmbedding,
+            maxNewTokens, temperature, topK, topP, repetitionPenalty);
+    }
+
+    private long[,,] GenerateInternal(int[] tokenIds, int speakerId, string language,
+                             float[]? speakerEmbedding,
+                             int maxNewTokens, float temperature,
+                             int topK, float topP,
+                             float repetitionPenalty)
+    {
         var cfg = _embeddings.Config;
         
         // Build prefill embedding
-        var (inputsEmbeds, trailingTextHidden) = BuildPrefillEmbedding(tokenIds, speakerId, language, cfg);
+        var (inputsEmbeds, trailingTextHidden) = BuildPrefillEmbedding(tokenIds, speakerId, language, cfg, speakerEmbedding);
         int prefillLen = inputsEmbeds.GetLength(1);
 
         // Attention mask: all 1s
@@ -247,7 +271,8 @@ internal sealed class LanguageModel : IDisposable
         return result;
     }
 
-    private (float[,,], float[,]) BuildPrefillEmbedding(int[] tokenIds, int speakerId, string language, ModelConfig cfg)
+    private (float[,,], float[,]) BuildPrefillEmbedding(int[] tokenIds, int speakerId, string language, ModelConfig cfg,
+        float[]? speakerEmbeddingOverride = null)
     {
         // Role embed: tokens [0:3]
         var roleEmbeds = new List<float[]>();
@@ -260,8 +285,9 @@ internal sealed class LanguageModel : IDisposable
             roleEmbeds.Add((float[])roleProjBuf.Clone());
         }
 
-        // Codec prefix
+        // Codec prefix — track speaker position for embedding override
         var codecPrefix = new List<int>();
+        int speakerPositionInPrefix = -1; // index of speaker token in codecPrefix
         if (language != "auto")
         {
             codecPrefix.Add(cfg.talker.codec_think_id);
@@ -276,9 +302,17 @@ internal sealed class LanguageModel : IDisposable
             codecPrefix.Add(cfg.talker.codec_think_eos_id);
         }
         
-        // Speaker token: only add when speakerId >= 0 (Base model has no speakers)
+        // Speaker token: add when speakerId >= 0, or when we have a speaker embedding override
         if (speakerId >= 0)
+        {
             codecPrefix.Add(speakerId);
+        }
+        else if (speakerEmbeddingOverride != null)
+        {
+            // Use pad_id as placeholder — the embedding will be overridden below
+            speakerPositionInPrefix = codecPrefix.Count;
+            codecPrefix.Add(cfg.talker.codec_pad_id);
+        }
         codecPrefix.Add(cfg.talker.codec_pad_id);
         codecPrefix.Add(cfg.talker.codec_bos_id);
 
@@ -304,10 +338,19 @@ internal sealed class LanguageModel : IDisposable
         
         for (int i = 0; i < codecPrefixLen - 2; i++)
         {
-            _embeddings.TalkerCodecEmbedding(codecPrefix[i], codecEmbBuf);
             var combined = new float[1024];
-            for (int j = 0; j < 1024; j++)
-                combined[j] = ttsPadProj[j] + codecEmbBuf[j];
+            if (i == speakerPositionInPrefix && speakerEmbeddingOverride != null)
+            {
+                // Inject the ECAPA-TDNN speaker embedding directly instead of codec table lookup
+                for (int j = 0; j < 1024; j++)
+                    combined[j] = ttsPadProj[j] + speakerEmbeddingOverride[j];
+            }
+            else
+            {
+                _embeddings.TalkerCodecEmbedding(codecPrefix[i], codecEmbBuf);
+                for (int j = 0; j < 1024; j++)
+                    combined[j] = ttsPadProj[j] + codecEmbBuf[j];
+            }
             talkerInputEmbeds.Add(combined);
         }
         

--- a/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceClonePipeline.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceClonePipeline.cs
@@ -85,20 +85,13 @@ public sealed class VoiceClonePipeline : IDisposable
     public async Task SynthesizeWithEmbeddingAsync(string text, float[] speakerEmbedding, string outputPath,
                                                     string language = "auto", IProgress<string>? progress = null)
     {
-        // For the Base model, speaker_ids.json is empty — voice identity comes from the ECAPA-TDNN embedding.
-        // Use speakerId = -1 to skip the speaker token in the codec prefix.
-        var speakers = _embeddings.GetAvailableSpeakers();
-        var hasSpeakers = speakers.Count > 0;
-        var placeholderSpeaker = hasSpeakers ? speakers.First() : "none";
-        var speakerId = hasSpeakers ? _embeddings.GetSpeakerId(placeholderSpeaker) : -1;
-
-        var tokenIds = _tokenizer.BuildCustomVoicePrompt(text, placeholderSpeaker, language, instruct: null);
+        var tokenIds = _tokenizer.BuildCustomVoicePrompt(text, "none", language, instruct: null);
         progress?.Report($"Tokenized input ({tokenIds.Length} tokens)");
         Console.WriteLine($"Generating speech ({tokenIds.Length} input tokens)...");
 
-        // Generate audio codes via LM (speakerId = -1 skips the speaker token)
+        // Generate audio codes via LM with the ECAPA-TDNN speaker embedding injected into the codec prefix
         progress?.Report("Running language model inference...");
-        var codes = _languageModel.GenerateWithSpeakerId(tokenIds, speakerId, language);
+        var codes = _languageModel.GenerateWithSpeakerEmbedding(tokenIds, speakerEmbedding, language);
 
         int timesteps = codes.GetLength(2);
         progress?.Report($"Generated {timesteps} audio frames");


### PR DESCRIPTION
**Problem:** Voice cloning produced generic voices — the ECAPA-TDNN speaker embedding was extracted from reference audio but never injected into the language model.

**Root cause:** \SynthesizeWithEmbeddingAsync\ called \GenerateWithSpeakerId(tokenIds, -1, language)\ which skipped the speaker position entirely in the codec prefix. The \speakerEmbedding\ parameter was accepted then discarded.

**How voice identity works:** Each prefill position = \	extProjection + codecEmbedding[tokenId]\. For CustomVoice, the speaker token ID maps to a 1024-dim vector via the codec embedding table. For voice cloning, the ECAPA-TDNN 1024-dim embedding should replace this lookup.

**Fix:**
- Added \LanguageModel.GenerateWithSpeakerEmbedding()\ that accepts \loat[]\ speaker embedding
- Modified \BuildPrefillEmbedding\ to inject the embedding at the speaker position: \combined[j] = ttsPadProj[j] + speakerEmbedding[j]\
- \VoiceClonePipeline\ now passes the ECAPA-TDNN embedding through to the LM

All 28 tests pass.