### PR TITLE
feat: ICL (In-Context Learning) mode for voice cloning (#32)

### DIFF
--- a/.squad/agents/trinity/history.md
+++ b/.squad/agents/trinity/history.md
@@ -1,0 +1,286 @@
+# Project Context
+
+- **Owner:** Bruno Capuano
+- **Project:** Qwen3-TTS → ONNX → C# .NET 10 console app for local voice generation
+- **Stack:** Python (PyTorch, transformers, ONNX), C# (.NET 10, ONNX Runtime), Qwen3-TTS
+- **Created:** 2026-02-21T15:38Z
+
+## Learnings
+
+<!-- Append new learnings below. Each entry is something lasting about the project. -->
+
+### 2026-02-21: Qwen3-TTS Architecture Deep Dive
+
+**Pipeline:** Text → BPE → Text Embedding (2048d) → Projection (→1024d) → Talker LM (20-layer, GQA 16/2, M-RoPE) → Code Predictor (5-layer, 31 autogressive steps per Talker step) → 32-codebook codes → Vocoder (16 codebooks used, RVQ dequantize → 8-layer transformer → BigVGAN-style conv decoder, 1920× upsample → 24kHz PCM)
+
+**Key architecture facts:**
+- Talker LM: hidden_size=1024, vocab_size=3072, num_code_groups=32
+- Code Predictor: 5 layers, hidden_size=1024, vocab_size=2048, predicts groups 1-31 sequentially
+- Vocoder (Tokenizer-12Hz): Decoder only (no ONNX internally), 16 RVQ codebooks, codebook_size=2048, sliding_window=72
+- 12Hz tokenizer is pure PyTorch — no ONNX files loaded at runtime
+- 25Hz tokenizer (not our target) DOES use ONNX internally
+- Total upsample factor = 1920× (12 Hz codes → 24kHz audio)
+
+**ONNX export plan:** 3 models — Vocoder (easiest, single pass), Code Predictor (small, 31-step loop), Talker LM (largest, KV-cache).
+
+**Key source files:**
+- `qwen_tts/core/models/modeling_qwen3_tts.py` — Talker LM + Code Predictor + Speaker Encoder
+- `qwen_tts/core/tokenizer_12hz/modeling_qwen3_tts_tokenizer_v2.py` — Vocoder
+- `qwen_tts/inference/qwen3_tts_model.py` — Inference orchestration
+
+**Environment:** `python/` directory created with requirements.txt, download_models.py, README.md, ARCHITECTURE.md
+
+### 2026-02-21: Talker LM + Code Predictor ONNX Export Scripts
+
+Created `python/export_lm.py` and `python/export_embeddings.py` for the two autoregressive components.
+
+**ONNX export approach:**
+- Wrapper `nn.Module` classes that take/return flat KV-cache tensors instead of HF DynamicCache
+- DynamicCache is reconstructed inside the wrapper forward() from flat tensors, then extracted after model call
+- This traces cleanly through `torch.onnx.export` because list operations (append/index) execute at trace time; only the tensor operations (concat, matmul) appear in the ONNX graph
+
+**Talker LM split into two ONNX models:**
+- `talker_prefill.onnx` — full sequence, produces initial KV cache (20 layers × K,V of shape B,2,T,128)
+- `talker_decode.onnx` — single token step, consumes and produces updated KV cache
+- Both use M-RoPE position_ids (3, B, T) as input; rotary embedding module baked into ONNX graph
+
+**Code Predictor — single ONNX model:**
+- `code_predictor.onnx` — handles both prefill (S=2) and decode (S=1) depending on input shape
+- 31 lm_head weight matrices stacked into a single buffer (31, 2048, 1024), indexed via `torch.index_select` on generation_steps input — avoids ModuleList dynamic indexing in ONNX
+- Uses standard 1D RoPE (not M-RoPE), 5 layers, 8 KV heads
+
+**Embedding extraction (`export_embeddings.py`):**
+- Saves text_embedding, text_projection MLP weights, talker codec_embedding (3072×1024), 31 code predictor codec embeddings (2048×1024 each), codec_head weights as .npy files
+- Exports speaker_ids.json (maps speaker names → token IDs in talker codec_embedding) and config.json with all special token IDs and model dimensions
+- C# loads these directly as raw tensors — no ONNX overhead for simple lookups
+
+### 2026-02-21: Vocoder ONNX Export Scripts
+
+Created `python/export_vocoder.py` and `python/validate_vocoder.py` for exporting the `Qwen3TTSTokenizerV2Decoder` to ONNX.
+
+**Decoder forward method** (verified from source):
+```python
+def forward(self, codes):  # (B, 16, T) int64
+    hidden = self.quantizer.decode(codes)      # RVQ dequantize → (B, codebook_dim, T)
+    hidden = self.pre_conv(hidden).transpose(1, 2)  # → (B, T, 1024)
+    hidden = self.pre_transformer(inputs_embeds=hidden).last_hidden_state  # 8-layer transformer
+    hidden = hidden.permute(0, 2, 1)           # → (B, 1024, T)
+    for blocks in self.upsample:               # 2×, 2× → (B, 1024, T×4)
+        for block in blocks: hidden = block(hidden)
+    wav = hidden
+    for block in self.decoder:                 # BigVGAN: 8×5×4×3 → (B, 1, T×1920)
+        wav = block(wav)
+    return wav.clamp(min=-1, max=1)
+```
+
+**Export strategy:** Two-attempt approach — trace-based first (opset 17), dynamo fallback (opset 18+). Dynamic axes on batch and time dimensions. The model is loaded from `Qwen/Qwen3-TTS-Tokenizer-12Hz` via `AutoModel.from_pretrained(..., trust_remote_code=True)` and the decoder extracted as `model.decoder`.
+
+**Potential ONNX issues to watch for at runtime:**
+- Sliding-window attention (window=72) in the 8-layer transformer may generate data-dependent masks
+- Causal convolution padding (`_get_extra_padding_for_conv1d`) uses input-length-dependent logic
+- RVQ decode has a for-loop over 16 codebook layers (should unroll since count is fixed)
+- SnakeBeta activation (`x + (1/β) * sin²(αx)`) uses only standard math ops — should be fine
+
+### 2026-02-21: BPE Tokenizer Extraction & Prompt Format Documentation
+
+**Tokenizer type:** Qwen2Tokenizer (GPT-2 style BPE, byte-level fallback). Uses `vocab.json` (151,936 entries) + `merges.txt`.
+
+**Chat template format (CustomVoice):**
+- Text wrapped as: `<|im_start|>assistant\n{text}<|im_end|>\n<|im_start|>assistant\n`
+- Instruct wrapped as: `<|im_start|>user\n{instruct}<|im_end|>\n` (prepended as embedding, not used for 0.6B model)
+- First 3 tokens (`<|im_start|>`, `assistant`, `\n`) are the "role prefix" — embedded separately
+
+**Codec prefix structure (Talker LM embedding space, NOT text tokens):**
+- Language="auto": `[nothink(2155), think_bos(2156), think_eos(2157)]`
+- Language explicit: `[think(2154), think_bos(2156), lang_id, think_eos(2157)]`
+- Then: `[speaker_embed?, pad(2148), bos(2149)]`
+
+**Key config IDs:** im_start=151644, im_end=151645, assistant=77091, tts_bos=151672, tts_eos=151673, tts_pad=151671
+
+**Dialect auto-mapping:** Eric → Sichuan (2062), Dylan → Beijing (2074) when language is "chinese" or "auto"
+
+**0.6B limitation:** Instruct parameter is forced to None for tts_model_size="0b6"
+
+**Files created:** `python/extract_tokenizer.py`, `python/TOKENIZER.md`, `python/tokenizer_artifacts/` (output dir)
+
+### 2026-02-21: GPU Handoff
+All Python export scripts are written and committed. None have been run yet — they need model weights downloaded first. On the GPU machine, run `download_models.py` first, then export scripts in order: vocoder → LM → embeddings → tokenizer. Watch for attribute path issues in export_lm.py — the model attribute discovery code has fallbacks but may need adjustment.
+
+### 2026-02-22: Qwen3-TTS 1.7B Technical Viability Analysis
+
+**Issue #26 analysis complete.** The 1.7B model is architecturally compatible with our 0.6B ONNX pipeline — only the Talker LM hidden size changes (1024→2048). Code Predictor (1024), vocoder, tokenizer, and speaker inventory remain identical.
+
+**Key findings:**
+- **Model variants:** 0.6B has Base+CustomVoice (no instruct). 1.7B has Base+CustomVoice+VoiceDesign (both with instruct). "Instruct" means natural-language style control (emotion, rate, timbre), not GPT-style instructions.
+- **Architecture:** Only `talker_config.hidden_size` (1024→2048) and `intermediate_size` (3072→6144) differ. Everything else (28 layers, 16 heads, 8 KV heads, head_dim=128, 16 code groups) is identical.
+- **Parameter count:** 0.6B = ~458M params (~1.8 GB FP32). 1.7B = ~1344M params (~5.4 GB FP32). Delta: +886M params (+3.5 GB).
+- **ONNX export feasibility:** Fully compatible. `python/export_lm.py` hardcodes `TALKER_HIDDEN = 1024` at line 29 — needs to read `model.config.talker_config.hidden_size` dynamically. No fundamental blockers.
+- **C# changes required:** `LanguageModel.cs` and `EmbeddingStore.cs` have ~100+ hardcoded `1024` references in buffer allocations. Solution: add `HiddenSize` property to config, replace all `1024` with `config.Talker.HiddenSize`.
+- **Resource requirements:** 16 GB RAM minimum for 1.7B (vs 8 GB for 0.6B). Inference ~2-2.5× slower. KV cache size per token is identical (224 KB) since head structure doesn't change.
+- **Implementation effort:** 8-12 hours for MVP (config-driven exporters + C# refactor + validation).
+
+**Documentation:** Full analysis written to `.squad/decisions/inbox/trinity-17b-viability.md` (16 KB, 9 sections covering variants, instruct semantics, architecture diffs, ONNX export, resource requirements, code changes, testing strategy, risks, recommendations).
+
+**Next steps:** Pending team decision. If approved, Phase 1 = make Python exporters config-driven → export 1.7B → refactor C# to be dimension-agnostic → add model size selection to TtsPipeline.
+
+### 2026-04-02T16:43Z: 1.7B Viability Analysis Complete & Approved for Implementation
+
+📌 Team update (2026-04-02T16:43Z): Orchestration logs and decision consolidation complete. Both Trinity and Morpheus recommend pursuing Phase 1 1.7B support (8-12 hours MVP). Non-breaking change, high user value (instruction control). Awaiting maintainer approval to start Phase 1 implementation. — Scribe
+
+### 2026-04-02: Python Export Scripts Made Config-Driven for 1.7B Support
+
+**Issue #26 Phase 1 (Python side) — complete.**
+
+**What changed:**
+- `export_lm.py`: Removed all hardcoded model constants (`TALKER_HIDDEN=1024`, `CP_HIDDEN=1024`, etc.). Added `read_model_dims(config)` function that extracts dimensions from `config.talker_config` and `code_predictor_config`. Wrapper classes (`TalkerPrefillWrapper`, `TalkerDecodeWrapper`, `CodePredictorWrapper`) now accept `num_layers` as constructor arg. Export functions accept `dims` dict.
+- `reexport_lm_novmap.py`: Same config-driven refactor + added `argparse` CLI with `--model-dir` and `--output-dir` (previously hardcoded paths).
+- `reexport_base_novmap.py`: Same config-driven refactor + added `argparse` CLI.
+- `download_models.py`: Added 1.7B variants. New `--model` choices: `customvoice-1.7b`, `all-1.7b`, `base-1.7b`, `everything`.
+- `extract_tokenizer.py`: Added `--model` CLI arg. Tokenizer is shared across variants.
+- `export_embeddings.py`: Already config-driven; updated docstring to document 1.7B support.
+- `python/README.md`: Added comprehensive 1.7B documentation including export commands, GPU requirements, and time estimates.
+- `python/ARCHITECTURE.md`: Updated Talker LM config table to show 0.6B vs 1.7B comparison.
+
+**Key pattern — `read_model_dims(config)`:**
+```python
+def read_model_dims(config):
+    tc = config.talker_config
+    cp = tc.code_predictor_config
+    return {
+        "talker_num_layers": tc.num_hidden_layers,
+        "talker_hidden": tc.hidden_size,
+        "cp_num_layers": cp.num_hidden_layers,
+        "cp_hidden": cp.hidden_size,
+        ...
+    }
+```
+This pattern should be reused if any new export scripts are added.
+
+**Unchanged files (no action needed):**
+- `export_vocoder.py` — vocoder architecture is independent of Talker hidden size
+- `export_speaker_encoder.py` — speaker encoder already reads config
+- `validate_vocoder.py` — vocoder-only validation
+- `patch_models_for_dml.py` — auto-detects dimensions from ONNX graph
+
+**0.6B backward compatibility:** All scripts retain 0.6B as default. Running without args produces identical behavior to before.
+
+📌 Team update (2026-04-02T1719): Phase 1 complete — multi-variant support (0.6B and 1.7B) implemented across C#, Python, and tests. Orchestration logs and decisions merged. Non-breaking change, 88 tests pass. — Scribe
+
+### 2026-04-02: Full 1.7B ONNX Export Pipeline — Complete
+
+**Environment:** NVIDIA A10-24Q (24 GB VRAM), Python 3.13.9, PyTorch 2.6.0+cu124, transformers 4.57.3, onnx 1.20.1
+
+**Model:** Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice (3.57 GB safetensors, BF16)
+
+**Exported artifacts (all to `python/onnx_1.7b/`):**
+
+| File | Size | Notes |
+|------|------|-------|
+| `talker_prefill.onnx` + `.data` | 2.7 MB + 5.27 GB | 28 layers, hidden=2048 |
+| `talker_decode.onnx` + `.data` | 2.7 MB + 5.27 GB | Same weights, decode-step graph |
+| `code_predictor.onnx` + `.data` | 0.2 MB + 428 MB | 5 layers, hidden=1024 (unchanged from 0.6B) |
+| `vocoder.onnx` | 436 MB | Shared across 0.6B/1.7B, validated (max err 2.5e-5) |
+| `embeddings/*.npy` + config | ~1.5 GB total | 15 CP embeddings (2048×2048), text_embedding (151936×2048) |
+| `tokenizer/` | ~4 MB | Shared vocab.json + merges.txt |
+
+**Total export size: ~12.8 GB** (vs ~5.5 GB for 0.6B — roughly 2.3× larger)
+
+**Issues encountered and fixed:**
+
+1. **vmap masking incompatibility (transformers 4.57.3):** `torch.onnx.export` trace fails with `RuntimeError: invalid unordered_map<K, T> key` because transformers' `masking_utils.py` uses `torch.vmap` for causal mask creation, which is incompatible with JIT tracing. **Fix:** Use `reexport_lm_novmap.py` which registers `sdpa_without_vmap` from `transformers.integrations.executorch`. Applied same fix to `export_vocoder.py`.
+
+2. **Code Predictor dummy input dimension bug (1.7B-only):** `export_lm.py` and `reexport_lm_novmap.py` created dummy CP inputs with `dims["cp_hidden"]` (1024), but `small_to_mtp_projection` expects `talker_hidden` (2048) as input. For 0.6B both are 1024 so it worked; for 1.7B it's a shape mismatch. **Fix:** Changed to `dims["talker_hidden"]` in both scripts.
+
+3. **ONNX external data scatter:** `torch.onnx.export` creates hundreds of individual tensor files. The original `fix_external_data_ref()` only renamed references without consolidating data, breaking the model. **Fix:** Replaced with `consolidate_external_data()` that loads all scattered data, then saves with `all_tensors_to_one_file=True`.
+
+**Validation results:**
+- Vocoder: ONNX vs PyTorch max error = 2.51e-5, mean error = 6.64e-7 ✓ PASS
+- LM models: Trace completed cleanly for all 3 (prefill, decode, code predictor)
+- Config.json verified: talker hidden_size=2048, cp hidden_size=1024
+
+**Upload:** All artifacts uploaded to `elbruno/Qwen3-TTS-12Hz-1.7B-CustomVoice-ONNX` on HuggingFace.
+
+**Script changes committed:**
+- `export_lm.py`: Fixed CP dummy input dimension (talker_hidden, not cp_hidden)
+- `reexport_lm_novmap.py`: Fixed CP dummy input + replaced broken `fix_external_data_ref` with `consolidate_external_data`
+- `export_vocoder.py`: Added vmap-free masking patch + `--output-dir` flag
+- `upload_to_hf.py`: Auto-detect model variant from config.json for README generation
+
+### 2026-04-03: Issue #27 Fix — Remove CP Projection from ONNX Graph
+
+**Root cause:** The `code_predictor.onnx` for 1.7B had `small_to_mtp_projection` (Linear: 2048→1024) baked into the ONNX graph via `CodePredictorWrapper.forward()`. This meant the ONNX model's `inputs_embeds` expected 2048-dim input. For CP prefill, C# feeds the talker hidden state (2048-dim) which got projected down to 1024 — correct. But for subsequent CP decode steps (groups 2-15), C# feeds 1024-dim codec embeddings, which the model tried to project from 2048→1024, causing shape mismatch and truncated output.
+
+**Fix applied to 4 Python export scripts:**
+1. `export_lm.py` — Removed `self.projection` from `CodePredictorWrapper` (was leaking ~400 MB unused weights into ONNX). Removed `self.projection(inputs_embeds)` from `forward()`. Changed dummy input dim from `talker_hidden` to `cp_hidden`.
+2. `reexport_lm_novmap.py` — Same wrapper fix + dummy dim fix.
+3. `reexport_base_novmap.py` — Same wrapper fix (dummy already used `cp_hidden`).
+4. `export_embeddings.py` — Added export of `cp_projection_weight.npy` (1024, 2048) and `cp_projection_bias.npy` (1024,) when `small_to_mtp_projection` attribute exists (1.7B only). 0.6B is safely skipped via `hasattr` check.
+
+**Key learning — nn.Module attribute leakage in ONNX:**
+Storing an `nn.Module` as `self.projection` in the wrapper causes `torch.onnx.export` to include its parameters in the graph as initializers, even if `forward()` never calls it. This doubled the ONNX data file from 420 MB to 890 MB. Fix: don't store unused submodules as wrapper attributes.
+
+**Re-export results:**
+- `code_predictor.onnx`: inputs_embeds shape = [batch, seq, **1024**] (was 2048) ✓
+- `code_predictor.onnx.data`: 420 MB (was 428 MB with projection baked in) ✓
+- `cp_projection_weight.npy`: (1024, 2048) float32, 8 MB ✓
+- `cp_projection_bias.npy`: (1024,) float32, 4 KB ✓
+
+**Uploaded to HuggingFace:** `elbruno/Qwen3-TTS-12Hz-1.7B-CustomVoice-ONNX` — all 4 files.
+
+### 2026-04-03: 1.7B Quality Investigation — Root Causes Identified
+
+**Issue:** 1.7B audio is recognizable but lower quality than expected compared to 0.6B.
+
+**Root cause found — Missing top_k=50 in Code Predictor sampling:**
+- `SampleTokenSimple()` (LanguageModel.cs:630) only applies temperature=0.9, no top_k filtering
+- Python reference uses `subtalker_top_k=50` via HuggingFace generate (confirmed in generation_config.json and modeling_qwen3_tts.py:2037)
+- Without top_k, CP samples from full 2048-token vocab, allowing noisy tail tokens
+- CP runs 15 times per talker step; errors compound across groups → audio artifacts
+
+**Secondary issue — Repetition penalty bug:**
+- C# always divides by penalty; HuggingFace divides positive logits but multiplies negative logits
+- Impact is low with penalty=1.05
+
+**Verified correct:**
+- CpProjection: `small_to_mtp_projection` applied uniformly to ALL CP inputs (hidden, group0, codec embeds) — C# matches Python exactly
+- Next talker input: CP codec embeddings are 2048-dim for 1.7B (embedding_dim = talker_hidden, not cp_hidden); all 2048 dims accumulated correctly
+- codec_head_weight.npy: not needed — codec_head is baked into talker ONNX models
+- Sampling params (talker): temperature=0.9, topK=50, topP=1.0, repPenalty=1.05 all match Python defaults
+
+**Key architectural insight confirmed:**
+- CP codec embeddings shape = (cp_vocab, talker_hidden) not (cp_vocab, cp_hidden)
+- `Qwen3TTSTalkerCodePredictorModel.__init__`: `nn.Embedding(config.vocab_size, embedding_dim)` where `embedding_dim = talker_config.hidden_size`
+- This means for 1.7B: CP codec embeddings are (2048, 2048), stored in talker space, projected to CP space (1024) only when fed to the CP model
+- For next talker input construction, the raw 2048-dim embeddings are summed WITHOUT projection — this is correct per Python source
+
+### 2026-07-18: Speech Tokenizer Encoder ONNX Export (Issue #32)
+
+**Exported:** `tokenizer12hz_encode.onnx` — the encoder portion of `Qwen3-TTS-Tokenizer-12Hz` for voice cloning ref_text support (ICL mode).
+
+**Architecture:** The encoder is `Qwen3TTSTokenizerV2Encoder`, a subclass of `MimiModel` (from transformers) with decoder parts removed. Pipeline:
+1. `MimiEncoder` (SEANet conv encoder) — downsamples audio 960× via strided Conv1d
+2. `MimiTransformerModel` (8 layers, sliding_window=250, hidden=512, GeLU) — contextualizes features
+3. `MimiConv1d` downsample (2×, converts 25Hz → 12.5Hz frame rate)
+4. `MimiSplitResidualVectorQuantizer` (32 RVQ codebooks, keep first 16)
+
+**ONNX tensors:**
+- Input: `audio_waveform` — (B, 1, T_samples) float32 — mono 24kHz audio, T must be multiple of 1920
+- Output: `audio_codes` — (B, 16, T_frames) int64 — values in [0, 2047], T_frames = T_samples / 1920
+
+**Key technical decisions:**
+1. **MimiConv1d padding patched to return 0** — `_get_extra_padding_for_conv1d` uses input-length-dependent math that bakes as constants during tracing. Patched to return 0; C# must pre-pad audio to multiples of 1920.
+2. **MimiTransformerModel bypassed** — `create_sliding_window_causal_mask` doesn't trace cleanly. The `EncoderOnnxWrapper` manually builds the sliding-window causal mask from tensor ops, iterates transformer layers directly.
+3. **Same compatibility patches as vocoder** — `check_model_inputs`, RoPE `"default"`, `sdpa_mask` scalar fix, `torch.diff` replacement, bool `cumsum` cast, GQA disabled, vmap-free masking.
+4. **No external data file** — Model is 209.6 MB (single ONNX file, no .data split needed). The encoder is much smaller than vocoder + LM models.
+
+**Validation results:** ONNX vs PyTorch exact match on all tests:
+- Sine wave (5 frames): exact match ✓
+- Dynamic axis (2, 10, 50 frames): all exact match ✓
+- Real audio file (6.56s Chinese speech, 82 frames): exact match ✓
+
+**MimiModel.encode() shape note:** Returns `(B, num_quantizers, T_frames)` NOT `(num_quantizers, B, T_frames)` — the `_encode_frame` method does `codes.transpose(0, 1)` before returning.
+
+**Files created:**
+- `python/export_speech_tokenizer.py` — export script
+- `python/onnx_models/tokenizer12hz_encode.onnx` — 209.6 MB ONNX model
+- Copied to `%LOCALAPPDATA%\ElBruno\QwenTTS-Base\tokenizer12hz_encode.onnx`

--- a/.squad/decisions/inbox/trinity-speech-tokenizer-export.md
+++ b/.squad/decisions/inbox/trinity-speech-tokenizer-export.md
@@ -1,0 +1,30 @@
+# Decision: Speech Tokenizer Encoder ONNX Export Strategy
+
+**Date:** 2026-07-18
+**Author:** Trinity (ML Engineer)
+**Status:** Implemented
+**Issue:** #32 (ref_text voice cloning support)
+
+## Context
+
+Voice cloning ICL (In-Context Learning) mode requires encoding reference audio into codebook tokens. The speech tokenizer encoder (Qwen3-TTS-Tokenizer-12Hz) was only available in PyTorch. We needed an ONNX export for the C# runtime.
+
+## Decision
+
+Export the encoder portion of `Qwen3TTSTokenizerV2Encoder` (which extends `MimiModel` from transformers) to ONNX as `tokenizer12hz_encode.onnx`.
+
+### Key design choices:
+
+1. **Wrapper approach** — Created `EncoderOnnxWrapper` that bypasses `create_sliding_window_causal_mask` and manually builds the attention mask. Same pattern as the vocoder export's `VocoderOnnxWrapper`.
+
+2. **Input constraint** — Audio length must be a multiple of 1920 samples (one frame at 12.5 Hz). This simplifies the ONNX graph by eliminating data-dependent padding. The C# runtime is responsible for padding.
+
+3. **Single file, no split** — At 209.6 MB the model fits in a single ONNX file (no external .data needed).
+
+4. **16 of 32 codebooks** — The RVQ has 32 codebooks but only the first 16 are valid for the 12Hz tokenizer. The wrapper enforces this at export time.
+
+## Impact on C# Side
+
+- **New file needed:** `tokenizer12hz_encode.onnx` must be downloaded alongside existing model files
+- **Input prep:** C# must pad audio to multiples of 1920 samples before inference
+- **Output:** (B, 16, T_frames) int64 codes — ready to feed into the TTS pipeline for ICL mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.4.0] - 2026-07-25
+
+### Added
+
+- **ICL (In-Context Learning) mode for voice cloning** ([#32](https://github.com/elbruno/ElBruno.QwenTTS/issues/32))
+  - New `SynthesizeAsync` overload accepting `refText` parameter for higher-quality voice cloning
+  - When reference text transcript is provided alongside reference audio, the model preserves accent characteristics (e.g., Trump voice speaking Chinese retains English accent)
+  - New `SpeechTokenizer` class wrapping `tokenizer12hz_encode.onnx` for audio → codec code extraction
+  - New `GenerateWithSpeakerEmbeddingAndRefText` method in `LanguageModel` for ICL prefill embedding
+  - Speech tokenizer encoder ONNX export script (`python/export_speech_tokenizer.py`)
+  - `tokenizer12hz_encode.onnx` added to `VoiceCloningDownloader` expected files
+  - 4 new ICL-specific unit tests
+
+### Fixed
+
+- SpeechTokenizer tensor shape/name compatibility with ONNX export (input: 3D `[B,1,T]`, output transpose `[B,16,T]→[B,T,16]`)
+
+## [v1.3.0] - 2026-07-24
+
+### Added
+
+- **1.7B model quality and performance improvements** ([#30](https://github.com/elbruno/ElBruno.QwenTTS/issues/30))
+
 ## [v1.2.3] - 2026-04-06
 
 First stable release (previously v1.2.3-preview).

--- a/python/export_speech_tokenizer.py
+++ b/python/export_speech_tokenizer.py
@@ -1,0 +1,598 @@
+"""
+Export Qwen3-TTS Tokenizer-12Hz ENCODER to ONNX.
+
+Extracts audio codes from reference audio waveforms for voice cloning (ICL mode).
+
+Input:  audio_waveform — shape (B, 1, T_samples) float32, 24 kHz mono PCM in [-1, 1]
+Output: audio_codes    — shape (B, 16, T_frames)  int64, values in [0, 2047]
+        where T_frames ≈ T_samples / 1920 (12.5 Hz frame rate)
+
+Architecture (Qwen3TTSTokenizerV2Encoder, extends MimiModel):
+  audio → MimiEncoder (SEANet conv, downsample 960×)
+        → MimiTransformerModel (8-layer, sliding_window=250, hidden=512)
+        → MimiConv1d downsample (2×, 25Hz→12.5Hz)
+        → MimiSplitResidualVectorQuantizer (32 RVQ, keep first 16 codebooks)
+        → audio_codes
+
+The encoder uses 32 RVQ codebooks internally but only the first 16 are
+valid (encoder_valid_num_quantizers=16).
+
+Usage:
+    python export_speech_tokenizer.py
+    python export_speech_tokenizer.py --model-dir models/Qwen3-TTS-Tokenizer-12Hz --output-dir onnx_models
+"""
+
+import argparse
+import math
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Compatibility patches (same as export_vocoder.py — needed for
+# transformers 5.5+ / qwen_tts interop)
+# ═══════════════════════════════════════════════════════════════════════════
+
+import transformers.utils.generic as _tug
+_orig_check = _tug.check_model_inputs
+
+def _compat_check_model_inputs(func=None):
+    if func is None:
+        return _orig_check
+    return _orig_check(func)
+
+_tug.check_model_inputs = _compat_check_model_inputs
+
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS as _ROPE_FNS
+if "default" not in _ROPE_FNS:
+    def _compute_default_rope(config=None, device=None, **kwargs):
+        base = config.rope_theta
+        head_dim = getattr(config, "head_dim", None)
+        if head_dim is None:
+            head_dim = config.hidden_size // config.num_attention_heads
+        inv_freq = 1.0 / (base ** (torch.arange(0, head_dim, 2, dtype=torch.int64).float().to(device) / head_dim))
+        return inv_freq, 1.0
+    _ROPE_FNS["default"] = _compute_default_rope
+
+# Patch sdpa_mask for scalar q_length during ONNX tracing
+import transformers.masking_utils as _masking
+_orig_sdpa_mask = _masking.sdpa_mask
+
+def _patched_sdpa_mask(q_length=None, **kwargs):
+    if isinstance(q_length, torch.Tensor):
+        if q_length.dim() == 0:
+            q_length = int(q_length.item())
+        else:
+            q_length = q_length.shape[0]
+    return _orig_sdpa_mask(q_length=q_length, **kwargs)
+
+_masking.sdpa_mask = _patched_sdpa_mask
+from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS as _MASK_FNS
+if 'sdpa' in _MASK_FNS:
+    _MASK_FNS['sdpa'] = _patched_sdpa_mask
+
+# Patch torch.diff for ONNX trace
+_orig_torch_diff = torch.diff
+
+def _onnx_safe_diff(input, n=1, dim=-1, prepend=None, append=None):
+    if n != 1:
+        return _orig_torch_diff(input, n=n, dim=dim, prepend=prepend, append=append)
+    parts = []
+    if prepend is not None:
+        parts.append(prepend)
+    parts.append(input)
+    if append is not None:
+        parts.append(append)
+    combined = torch.cat(parts, dim=dim) if len(parts) > 1 else input
+    return torch.narrow(combined, dim, 1, combined.size(dim) - 1) - torch.narrow(combined, dim, 0, combined.size(dim) - 1)
+
+torch.diff = _onnx_safe_diff
+
+# Patch bool cumsum for ONNX
+_orig_cumsum = torch.Tensor.cumsum
+
+def _onnx_safe_cumsum(self, dim, dtype=None):
+    if self.dtype == torch.bool:
+        return _orig_cumsum(self.to(torch.int64), dim, dtype=dtype)
+    return _orig_cumsum(self, dim, dtype=dtype)
+
+torch.Tensor.cumsum = _onnx_safe_cumsum
+
+# Disable GQA in SDPA (not needed for Mimi — num_kv_heads == num_heads)
+import transformers.integrations.sdpa_attention as _sdpa_mod
+_sdpa_mod.use_gqa_in_sdpa = lambda attention_mask, key: False
+
+# Register vmap-free masking
+try:
+    from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+    from transformers.integrations.executorch import sdpa_mask_without_vmap
+    ALL_MASK_ATTENTION_FUNCTIONS.register('sdpa_without_vmap', sdpa_mask_without_vmap)
+    ALL_ATTENTION_FUNCTIONS.register('sdpa_without_vmap', ALL_ATTENTION_FUNCTIONS['sdpa'])
+    _VMAP_WORKAROUND = 'sdpa_without_vmap'
+except ImportError:
+    _VMAP_WORKAROUND = None
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Constants
+# ═══════════════════════════════════════════════════════════════════════════
+
+TOKENIZER_REPO = "Qwen/Qwen3-TTS-Tokenizer-12Hz"
+DEFAULT_OUTPUT_DIR = Path(__file__).parent / "onnx_models"
+ONNX_FILENAME = "tokenizer12hz_encode.onnx"
+
+SAMPLE_RATE = 24000
+ENCODE_DOWNSAMPLE = 1920
+VALID_NUM_QUANTIZERS = 16
+NUM_TOTAL_QUANTIZERS = 32
+CODEBOOK_SIZE = 2048
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ONNX-friendly Encoder Wrapper
+# ═══════════════════════════════════════════════════════════════════════════
+
+class EncoderOnnxWrapper(nn.Module):
+    """ONNX-friendly wrapper for the Qwen3-TTS speech tokenizer encoder.
+
+    Bypasses create_sliding_window_causal_mask in the MimiTransformerModel
+    and manually builds the mask from tensor ops (ONNX-traceable).
+
+    Pipeline:
+      audio (B, 1, T) → SEANet encoder → transformer → downsample → RVQ → codes (B, 16, T')
+    """
+
+    def __init__(self, encoder_model, valid_num_quantizers=VALID_NUM_QUANTIZERS):
+        super().__init__()
+        # encoder_model is the Qwen3TTSTokenizerV2Encoder (extends MimiModel)
+        self.seanet_encoder = encoder_model.encoder
+        self.encoder_transformer = encoder_model.encoder_transformer
+        self.downsample = encoder_model.downsample
+        self.quantizer = encoder_model.quantizer
+        self.valid_num_quantizers = valid_num_quantizers
+
+        config = encoder_model.encoder_transformer.config
+        self.sliding_window = getattr(config, "sliding_window", 250)
+
+    def _make_sliding_window_causal_mask(self, seq_len, device):
+        """Build a sliding-window causal float mask: (1, 1, S, S).
+
+        attend[q, kv] = 0.0 if allowed, -inf if blocked.
+        """
+        pos = torch.arange(seq_len, device=device)
+        q_pos = pos.unsqueeze(1)
+        kv_pos = pos.unsqueeze(0)
+        diff = q_pos - kv_pos
+        allowed = (diff >= 0) & (diff < self.sliding_window)
+        mask = torch.where(allowed, torch.tensor(0.0, device=device),
+                           torch.tensor(-3.4028e+38, device=device))
+        return mask.unsqueeze(0).unsqueeze(0)
+
+    def forward(self, audio_waveform):
+        """
+        Args:
+            audio_waveform: (B, 1, T_samples) float32 — mono 24kHz audio
+
+        Returns:
+            audio_codes: (B, valid_num_quantizers, T_frames) int64
+        """
+        # 1. SEANet convolutional encoder
+        embeddings = self.seanet_encoder(audio_waveform)  # (B, hidden=512, T_enc)
+
+        # 2. Transformer (bypass create_sliding_window_causal_mask)
+        hidden_states = embeddings.transpose(1, 2)  # (B, T_enc, 512)
+        transformer = self.encoder_transformer
+
+        seq_len = hidden_states.shape[1]
+        device = hidden_states.device
+        position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+
+        causal_mask = self._make_sliding_window_causal_mask(seq_len, device)
+
+        for layer in transformer.layers:
+            layer_outputs = layer(
+                hidden_states,
+                attention_mask=causal_mask,
+                position_ids=position_ids,
+                past_key_values=None,
+                output_attentions=False,
+                use_cache=False,
+            )
+            hidden_states = layer_outputs[0]
+
+        embeddings = hidden_states.transpose(1, 2)  # (B, 512, T_enc)
+
+        # 3. Downsample (25Hz → 12.5Hz)
+        embeddings = self.downsample(embeddings)
+
+        # 4. RVQ encode (returns shape: (num_quantizers, B, T_frames))
+        codes = self.quantizer.encode(embeddings, self.valid_num_quantizers)
+        codes = codes.transpose(0, 1)  # (B, num_quantizers, T_frames)
+
+        return codes
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Model loading
+# ═══════════════════════════════════════════════════════════════════════════
+
+def _fix_rope_inv_freq(transformer):
+    """Recompute RoPE inv_freq (may be uninitialized after meta-device loading)."""
+    for layer in transformer.layers:
+        if not hasattr(layer, 'self_attn'):
+            continue
+        rotary = layer.self_attn.rotary_emb
+        config = layer.self_attn.config
+        head_dim = getattr(config, "head_dim", None)
+        if head_dim is None:
+            head_dim = config.hidden_size // config.num_attention_heads
+        theta = getattr(config, "rope_theta", 10000.0)
+        inv_freq = 1.0 / (theta ** (torch.arange(0, head_dim, 2, dtype=torch.float32) / head_dim))
+        rotary.inv_freq = inv_freq
+    print(f"  Fixed RoPE inv_freq for {len(transformer.layers)} transformer layers")
+
+
+def load_encoder(local_dir=None):
+    """Load the Qwen3-TTS-Tokenizer-12Hz model and extract the encoder."""
+    from transformers.models.mimi.modeling_mimi import MimiConv1d
+
+    # Patch MimiConv1d._get_extra_padding_for_conv1d to return 0.
+    # During ONNX tracing, the original uses input-length-dependent math
+    # that gets baked as constants. Returning 0 is correct when the C#
+    # runtime pre-pads audio to multiples of ENCODE_DOWNSAMPLE (1920).
+    MimiConv1d._get_extra_padding_for_conv1d = lambda self, hidden_states: 0
+
+    from qwen_tts.core.tokenizer_12hz.configuration_qwen3_tts_tokenizer_v2 import (
+        Qwen3TTSTokenizerV2Config,
+    )
+    from qwen_tts.core.tokenizer_12hz.modeling_qwen3_tts_tokenizer_v2 import (
+        Qwen3TTSTokenizerV2Model,
+    )
+
+    repo = local_dir or TOKENIZER_REPO
+    print(f"Loading model from {repo} ...")
+    config = Qwen3TTSTokenizerV2Config.from_pretrained(repo)
+
+    # Force eager attention for ONNX export
+    config.encoder_config._attn_implementation = "eager"
+
+    model = Qwen3TTSTokenizerV2Model.from_pretrained(repo, config=config)
+    model.eval()
+
+    encoder = model.encoder  # Qwen3TTSTokenizerV2Encoder (MimiModel subclass)
+    print(f"  Encoder class: {type(encoder).__name__}")
+    print(f"  Encoder config: hidden_size={config.encoder_config.hidden_size}, "
+          f"num_layers={config.encoder_config.num_hidden_layers}, "
+          f"sliding_window={config.encoder_config.sliding_window}")
+    print(f"  Quantizer: {config.encoder_config.num_quantizers} codebooks, "
+          f"valid={config.encoder_valid_num_quantizers}")
+    print(f"  Downsample rate: {config.encode_downsample_rate}")
+
+    # Fix RoPE inv_freq
+    _fix_rope_inv_freq(encoder.encoder_transformer)
+
+    # Patch transformer for vmap-free masking
+    if _VMAP_WORKAROUND and hasattr(encoder, 'encoder_transformer'):
+        print(f"  Patching attention to '{_VMAP_WORKAROUND}' for ONNX trace ...")
+        encoder.encoder_transformer.config._attn_implementation = _VMAP_WORKAROUND
+        for layer in encoder.encoder_transformer.layers:
+            if hasattr(layer, 'self_attn'):
+                layer.self_attn.config._attn_implementation = _VMAP_WORKAROUND
+
+    # Create ONNX-friendly wrapper
+    wrapper = EncoderOnnxWrapper(encoder, config.encoder_valid_num_quantizers)
+    wrapper.eval()
+
+    # Verify wrapper against original encode path
+    print("\n  Verifying wrapper vs original encode ...")
+    test_samples = ENCODE_DOWNSAMPLE * 5  # 5 frames
+    test_audio = torch.randn(1, 1, test_samples)
+
+    with torch.no_grad():
+        # Original path: MimiModel._encode_frame does codes.transpose(0,1),
+        # so audio_codes is (B, num_quantizers, T_frames)
+        orig_output = model.encoder.encode(
+            input_values=test_audio, return_dict=True
+        )
+        orig_codes = orig_output.audio_codes  # (B, num_quantizers, T_frames)
+        orig_codes = orig_codes[:, :VALID_NUM_QUANTIZERS]  # (B, 16, T)
+
+        # Wrapper path
+        wrap_codes = wrapper(test_audio)  # (B, 16, T)
+
+    match = torch.equal(orig_codes, wrap_codes)
+    print(f"  Original codes shape: {tuple(orig_codes.shape)}")
+    print(f"  Wrapper codes shape:  {tuple(wrap_codes.shape)}")
+    print(f"  Exact match: {match}")
+    if not match:
+        diff_count = (orig_codes != wrap_codes).sum().item()
+        total = orig_codes.numel()
+        print(f"  WARNING: {diff_count}/{total} codes differ")
+        # This can happen due to floating point differences in the transformer
+        # affecting which codebook entry is closest. Small differences are OK.
+
+    return wrapper, model
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Dummy input
+# ═══════════════════════════════════════════════════════════════════════════
+
+def create_dummy_input(num_frames=5):
+    """Create a dummy audio waveform for export tracing.
+
+    The input length must be a multiple of ENCODE_DOWNSAMPLE for clean framing.
+    """
+    num_samples = ENCODE_DOWNSAMPLE * num_frames
+    return torch.randn(1, 1, num_samples)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# ONNX export
+# ═══════════════════════════════════════════════════════════════════════════
+
+def export_onnx(wrapper, audio, output_path, opset=17):
+    """Export encoder to ONNX."""
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"\nInput shape:  {tuple(audio.shape)}  (batch, channels, samples)")
+    with torch.no_grad():
+        codes_pt = wrapper(audio)
+    print(f"Output shape: {tuple(codes_pt.shape)}  (batch, codebooks, frames)")
+    print(f"Frame check: {audio.shape[-1]} / {ENCODE_DOWNSAMPLE} = "
+          f"{audio.shape[-1] / ENCODE_DOWNSAMPLE:.1f} frames  (got {codes_pt.shape[-1]})")
+    print(f"Code value range: [{codes_pt.min().item()}, {codes_pt.max().item()}]")
+
+    dynamic_axes = {
+        "audio_waveform": {0: "batch_size", 2: "num_samples"},
+        "audio_codes":    {0: "batch_size", 2: "num_frames"},
+    }
+
+    # Attempt 1: trace-based export
+    try:
+        print(f"\n[1/2] torch.onnx.export (trace, opset {opset}) ...")
+        t0 = time.time()
+        torch.onnx.export(
+            wrapper,
+            (audio,),
+            str(output_path),
+            opset_version=opset,
+            input_names=["audio_waveform"],
+            output_names=["audio_codes"],
+            dynamic_axes=dynamic_axes,
+            do_constant_folding=False,
+        )
+        elapsed = time.time() - t0
+        size_mb = output_path.stat().st_size / (1024 * 1024)
+        print(f"  ✓ Exported in {elapsed:.1f}s  ({size_mb:.1f} MB)")
+
+        # Check for external data files
+        data_path = Path(str(output_path) + ".data")
+        if data_path.exists():
+            data_mb = data_path.stat().st_size / (1024 * 1024)
+            print(f"  External data: {data_path.name} ({data_mb:.1f} MB)")
+
+        return True
+    except Exception as e:
+        print(f"  ✗ Trace export failed: {e}")
+        import traceback
+        traceback.print_exc()
+
+    # Attempt 2: dynamo-based export
+    try:
+        dynamo_opset = max(opset, 18)
+        print(f"\n[2/2] torch.onnx.export (dynamo, opset {dynamo_opset}) ...")
+        t0 = time.time()
+        torch.onnx.export(
+            wrapper,
+            (audio,),
+            str(output_path),
+            opset_version=dynamo_opset,
+            input_names=["audio_waveform"],
+            output_names=["audio_codes"],
+            dynamic_axes=dynamic_axes,
+            dynamo=True,
+        )
+        elapsed = time.time() - t0
+        size_mb = output_path.stat().st_size / (1024 * 1024)
+        print(f"  ✓ Exported (dynamo) in {elapsed:.1f}s  ({size_mb:.1f} MB)")
+        return True
+    except Exception as e:
+        print(f"  ✗ Dynamo export also failed: {e}")
+        import traceback
+        traceback.print_exc()
+
+    return False
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Validation
+# ═══════════════════════════════════════════════════════════════════════════
+
+def validate(wrapper, original_model, output_path):
+    """Validate ONNX model against PyTorch output."""
+    import onnxruntime as ort
+
+    output_path = Path(output_path)
+    if not output_path.exists():
+        print("\nSkipping validation — no ONNX file found.")
+        return False
+
+    print("\n" + "=" * 60)
+    print("Validation: PyTorch vs ONNX Runtime")
+    print("=" * 60)
+
+    # Test 1: Simple sine wave
+    print("\n--- Test 1: Sine wave (5 frames = 9600 samples) ---")
+    num_samples = ENCODE_DOWNSAMPLE * 5
+    t = torch.linspace(0, 2 * math.pi * 440 * num_samples / SAMPLE_RATE, num_samples)
+    sine_audio = (0.5 * torch.sin(t)).unsqueeze(0).unsqueeze(0)  # (1, 1, T)
+
+    with torch.no_grad():
+        pt_codes = wrapper(sine_audio).numpy()
+
+    sess = ort.InferenceSession(str(output_path), providers=["CPUExecutionProvider"])
+    ort_codes = sess.run(["audio_codes"], {"audio_waveform": sine_audio.numpy()})[0]
+
+    print(f"  PT shape:   {pt_codes.shape}")
+    print(f"  ONNX shape: {ort_codes.shape}")
+    match1 = np.array_equal(pt_codes, ort_codes)
+    if not match1:
+        diff = (pt_codes != ort_codes).sum()
+        total = pt_codes.size
+        print(f"  Exact match: False ({diff}/{total} codes differ)")
+    else:
+        print(f"  Exact match: True ✓")
+
+    # Test 2: Different lengths (dynamic axis check)
+    print("\n--- Test 2: Dynamic axis (different audio lengths) ---")
+    all_pass = True
+    for num_frames in [2, 10, 50]:
+        ns = ENCODE_DOWNSAMPLE * num_frames
+        test_audio = torch.randn(1, 1, ns)
+        with torch.no_grad():
+            pt_out = wrapper(test_audio).numpy()
+        ort_out = sess.run(["audio_codes"], {"audio_waveform": test_audio.numpy()})[0]
+        match = np.array_equal(pt_out, ort_out)
+        status = "✓" if match else "✗"
+        diff_count = 0 if match else (pt_out != ort_out).sum()
+        print(f"  {num_frames:3d} frames ({ns:>7d} samples): "
+              f"shape={ort_out.shape}, match={status}"
+              + (f" ({diff_count} diffs)" if not match else ""))
+        if not match:
+            all_pass = False
+
+    # Test 3: Real audio file (if available)
+    print("\n--- Test 3: Real audio file ---")
+    wav_files = list(Path(__file__).parent.parent.glob("*.wav"))
+    if wav_files:
+        wav_path = wav_files[0]
+        print(f"  Loading {wav_path.name} ...")
+        try:
+            import wave
+            with wave.open(str(wav_path), 'rb') as wf:
+                assert wf.getnchannels() == 1, f"Expected mono, got {wf.getnchannels()} channels"
+                assert wf.getframerate() == SAMPLE_RATE, f"Expected {SAMPLE_RATE}Hz, got {wf.getframerate()}Hz"
+                frames = wf.readframes(wf.getnframes())
+                audio_np = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+
+            # Pad to multiple of ENCODE_DOWNSAMPLE
+            pad_len = (ENCODE_DOWNSAMPLE - len(audio_np) % ENCODE_DOWNSAMPLE) % ENCODE_DOWNSAMPLE
+            if pad_len > 0:
+                audio_np = np.pad(audio_np, (0, pad_len))
+
+            real_audio = torch.from_numpy(audio_np).unsqueeze(0).unsqueeze(0)  # (1, 1, T)
+            print(f"  Audio: {real_audio.shape[-1]} samples ({real_audio.shape[-1]/SAMPLE_RATE:.2f}s)")
+
+            with torch.no_grad():
+                pt_out = wrapper(real_audio).numpy()
+            ort_out = sess.run(["audio_codes"], {"audio_waveform": real_audio.numpy()})[0]
+
+            match = np.array_equal(pt_out, ort_out)
+            diff_count = 0 if match else (pt_out != ort_out).sum()
+            print(f"  Codes shape: {ort_out.shape}")
+            print(f"  Exact match: {match}" + (f" ({diff_count} diffs)" if not match else " ✓"))
+            print(f"  Code value range: [{ort_out.min()}, {ort_out.max()}]")
+            if not match:
+                all_pass = False
+        except Exception as e:
+            print(f"  Skipped: {e}")
+    else:
+        print("  No .wav files found — skipped")
+
+    overall = all_pass and match1
+    print(f"\n{'✓ ALL TESTS PASSED' if overall else '⚠ SOME DIFFERENCES DETECTED (may be acceptable)'}")
+    print("Note: Small code differences are normal — floating point rounding in "
+          "the transformer can shift which codebook entry is nearest.")
+    return overall
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CLI
+# ═══════════════════════════════════════════════════════════════════════════
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Export Qwen3-TTS Tokenizer-12Hz encoder to ONNX"
+    )
+    p.add_argument(
+        "--model-dir", type=str, default=None,
+        help="Local directory with tokenizer model weights "
+             "(default: download from HF or use models/Qwen3-TTS-Tokenizer-12Hz/)",
+    )
+    p.add_argument(
+        "--output-dir", type=str, default=None,
+        help=f"Directory to save {ONNX_FILENAME} (default: onnx_models/)",
+    )
+    p.add_argument(
+        "--opset", type=int, default=17,
+        help="ONNX opset version (default: 17)",
+    )
+    p.add_argument(
+        "--num-frames", type=int, default=5,
+        help="Number of encoder frames for dummy input (default: 5)",
+    )
+    p.add_argument(
+        "--skip-validate", action="store_true",
+        help="Skip ONNX Runtime validation after export",
+    )
+    p.add_argument(
+        "--copy-to-local", action="store_true",
+        help="Copy exported ONNX to %%LOCALAPPDATA%%\\ElBruno\\QwenTTS-Base\\",
+    )
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    output_dir = Path(args.output_dir) if args.output_dir else DEFAULT_OUTPUT_DIR
+    output_path = output_dir / ONNX_FILENAME
+
+    # Auto-detect local model dir
+    model_dir = args.model_dir
+    if model_dir is None:
+        local_candidate = Path(__file__).parent / "models" / "Qwen3-TTS-Tokenizer-12Hz"
+        if local_candidate.exists():
+            model_dir = str(local_candidate)
+            print(f"Using local model: {model_dir}")
+
+    print("=" * 60)
+    print("Qwen3-TTS Speech Tokenizer Encoder → ONNX Export")
+    print("=" * 60)
+
+    wrapper, original_model = load_encoder(model_dir)
+    audio = create_dummy_input(args.num_frames)
+
+    with torch.no_grad():
+        success = export_onnx(wrapper, audio, output_path, opset=args.opset)
+
+    if success and not args.skip_validate:
+        validate(wrapper, original_model, output_path)
+
+    if success and args.copy_to_local:
+        local_app = os.environ.get("LOCALAPPDATA")
+        if local_app:
+            dest_dir = Path(local_app) / "ElBruno" / "QwenTTS-Base"
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            import shutil
+            shutil.copy2(output_path, dest_dir / ONNX_FILENAME)
+            print(f"\nCopied to {dest_dir / ONNX_FILENAME}")
+            # Copy .data file if it exists
+            data_file = Path(str(output_path) + ".data")
+            if data_file.exists():
+                shutil.copy2(data_file, dest_dir / (ONNX_FILENAME + ".data"))
+                print(f"Copied to {dest_dir / (ONNX_FILENAME + '.data')}")
+
+    print("\nDone." if success else "\nExport failed.")
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ElBruno.QwenTTS.Core/ElBruno.QwenTTS.Core.csproj
+++ b/src/ElBruno.QwenTTS.Core/ElBruno.QwenTTS.Core.csproj
@@ -15,7 +15,7 @@
     <PackageIcon>nuget_01.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>tts;text-to-speech;qwen;onnx;ai;local;speech-synthesis;voice;audio;machine-learning</PackageTags>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ElBruno.QwenTTS.Core/Models/LanguageModel.cs
+++ b/src/ElBruno.QwenTTS.Core/Models/LanguageModel.cs
@@ -131,16 +131,48 @@ internal sealed class LanguageModel : IDisposable
             maxNewTokens, temperature, topK, topP, repetitionPenalty);
     }
 
+    /// <summary>
+    /// Generate audio codes using a speaker embedding and optional ICL reference data.
+    /// When refTokenIds and refAudioCodes are provided, enables In-Context Learning mode
+    /// where the model uses both reference text and reference audio codes for higher-quality
+    /// voice cloning.
+    /// </summary>
+    /// <param name="tokenIds">Target text token IDs from the prompt builder.</param>
+    /// <param name="speakerEmbedding">1024-dim ECAPA-TDNN speaker embedding.</param>
+    /// <param name="language">Language code (e.g., "english", "chinese", "auto").</param>
+    /// <param name="refTokenIds">Optional reference text token IDs for ICL mode.</param>
+    /// <param name="refAudioCodes">Optional reference audio codes [1, T, 16] for ICL mode.</param>
+    /// <param name="maxNewTokens">Maximum number of audio frames to generate.</param>
+    /// <param name="temperature">Sampling temperature.</param>
+    /// <param name="topK">Top-k sampling parameter.</param>
+    /// <param name="topP">Top-p (nucleus) sampling parameter.</param>
+    /// <param name="repetitionPenalty">Repetition penalty factor.</param>
+    public long[,,] GenerateWithSpeakerEmbeddingAndRefText(
+        int[] tokenIds, float[] speakerEmbedding, string language,
+        int[]? refTokenIds = null, long[,,]? refAudioCodes = null,
+        int maxNewTokens = 2048, float temperature = 0.9f,
+        int topK = 50, float topP = 1.0f,
+        float repetitionPenalty = 1.05f)
+    {
+        return GenerateInternal(tokenIds, speakerId: -1, language, speakerEmbedding,
+            maxNewTokens, temperature, topK, topP, repetitionPenalty,
+            refTokenIds, refAudioCodes);
+    }
+
     private long[,,] GenerateInternal(int[] tokenIds, int speakerId, string language,
                              float[]? speakerEmbedding,
                              int maxNewTokens, float temperature,
                              int topK, float topP,
-                             float repetitionPenalty)
+                             float repetitionPenalty,
+                             int[]? refTokenIds = null,
+                             long[,,]? refAudioCodes = null)
     {
         var cfg = _embeddings.Config;
         
         // Build prefill embedding
-        var (inputsEmbeds, trailingTextHidden) = BuildPrefillEmbedding(tokenIds, speakerId, language, cfg, speakerEmbedding);
+        var (inputsEmbeds, trailingTextHidden) = BuildPrefillEmbedding(
+            tokenIds, speakerId, language, cfg, speakerEmbedding,
+            refTokenIds, refAudioCodes);
         int prefillLen = inputsEmbeds.GetLength(1);
 
         // Attention mask: all 1s
@@ -388,7 +420,8 @@ internal sealed class LanguageModel : IDisposable
     }
 
     private (float[,,], float[,]) BuildPrefillEmbedding(int[] tokenIds, int speakerId, string language, ModelConfig cfg,
-        float[]? speakerEmbeddingOverride = null)
+        float[]? speakerEmbeddingOverride = null,
+        int[]? refTokenIds = null, long[,,]? refAudioCodes = null)
     {
         // Role embed: tokens [0:3]
         var roleEmbeds = new List<float[]>();
@@ -472,7 +505,46 @@ internal sealed class LanguageModel : IDisposable
             }
             talkerInputEmbeds.Add(combined);
         }
-        
+
+        // ICL section: insert reference text and audio code embeddings before the transition marker
+        bool hasIclData = refTokenIds != null && refAudioCodes != null;
+        if (hasIclData)
+        {
+            // Pre-compute codec_pad embedding (reused for all ref text tokens)
+            var codecPadEmbed = new float[_hiddenSize];
+            _embeddings.TalkerCodecEmbedding(cfg.talker.codec_pad_id, codecPadEmbed);
+
+            // Ref text embeddings: textProj(refToken) + codec_pad_embed
+            var refTextEmbBuf = new float[2048];
+            var refProjBuf = new float[_hiddenSize];
+            for (int i = 0; i < refTokenIds!.Length; i++)
+            {
+                _embeddings.TextEmbedding(refTokenIds[i], refTextEmbBuf);
+                _embeddings.TextProjection(refTextEmbBuf, refProjBuf);
+                var combined = new float[_hiddenSize];
+                for (int j = 0; j < _hiddenSize; j++)
+                    combined[j] = refProjBuf[j] + codecPadEmbed[j];
+                talkerInputEmbeds.Add(combined);
+            }
+
+            // Ref audio code embeddings: ttsPadProj + sum(TalkerCodecEmbed(codes[t][g]) for g=0..15)
+            int tFrames = refAudioCodes!.GetLength(1);
+            for (int t = 0; t < tFrames; t++)
+            {
+                var combined = new float[_hiddenSize];
+                for (int j = 0; j < _hiddenSize; j++)
+                    combined[j] = ttsPadProj[j];
+
+                for (int g = 0; g < 16; g++)
+                {
+                    _embeddings.TalkerCodecEmbedding((int)refAudioCodes[0, t, g], codecEmbBuf);
+                    for (int j = 0; j < _hiddenSize; j++)
+                        combined[j] += codecEmbBuf[j];
+                }
+                talkerInputEmbeds.Add(combined);
+            }
+        }
+
         // Last position: tts_bos + codec_prefix[-2]
         {
             _embeddings.TalkerCodecEmbedding(codecPrefix[codecPrefixLen - 2], codecEmbBuf);
@@ -482,7 +554,7 @@ internal sealed class LanguageModel : IDisposable
             talkerInputEmbeds.Add(combined);
         }
 
-        // Combine: role_embed + _talker_input_embed
+        // Combine: role_embed + _talker_input_embed (includes ICL section when present)
         var allEmbeds = new List<float[]>();
         allEmbeds.AddRange(roleEmbeds);
         allEmbeds.AddRange(talkerInputEmbeds);

--- a/src/ElBruno.QwenTTS.VoiceCloning.Tests/VoiceCloningTests.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning.Tests/VoiceCloningTests.cs
@@ -169,6 +169,24 @@ public class SpeakerEncoderTests
     }
 }
 
+public class SpeechTokenizerTests
+{
+    [Fact]
+    public void Constructor_ThrowsIfModelNotFound()
+    {
+        Assert.Throws<FileNotFoundException>(() =>
+            new SpeechTokenizer("nonexistent_tokenizer.onnx"));
+    }
+
+    [Fact]
+    public void Constants_AreCorrect()
+    {
+        Assert.Equal(24000, SpeechTokenizer.SampleRate);
+        Assert.Equal(1920, SpeechTokenizer.SamplesPerFrame);
+        Assert.Equal(16, SpeechTokenizer.NumCodebooks);
+    }
+}
+
 public class VoiceClonePipelineTests
 {
     [Fact]
@@ -185,5 +203,33 @@ public class VoiceClonePipelineTests
         {
             Directory.Delete(tempDir, recursive: true);
         }
+    }
+}
+
+public class VoiceCloningDownloaderIclTests
+{
+    [Fact]
+    public void ExpectedFiles_IncludesSpeechTokenizer()
+    {
+        // Verify that IsModelDownloaded checks for the speech tokenizer ONNX model.
+        // An empty dir should return false, confirming tokenizer12hz_encode.onnx is expected.
+        var tempDir = Path.Combine(Path.GetTempPath(), $"vc_icl_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            Assert.False(VoiceCloningDownloader.IsModelDownloaded(tempDir));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DefaultRepoId_IsValid()
+    {
+        Assert.False(string.IsNullOrEmpty(VoiceCloningDownloader.DefaultRepoId));
+        Assert.Contains("/", VoiceCloningDownloader.DefaultRepoId);
     }
 }

--- a/src/ElBruno.QwenTTS.VoiceCloning/Audio/MelSpectrogram.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Audio/MelSpectrogram.cs
@@ -109,7 +109,7 @@ public static class MelSpectrogram
         return Extract(samples, DefaultSampleRate);
     }
 
-    private static (float[] samples, int sampleRate) ReadWav(string path)
+    internal static (float[] samples, int sampleRate) ReadWav(string path)
     {
         using var stream = File.OpenRead(path);
         using var reader = new BinaryReader(stream);
@@ -175,7 +175,7 @@ public static class MelSpectrogram
         throw new InvalidDataException("WAV file has no data chunk");
     }
 
-    private static float[] Resample(float[] input, int fromRate, int toRate)
+    internal static float[] Resample(float[] input, int fromRate, int toRate)
     {
         double ratio = (double)toRate / fromRate;
         int outputLen = (int)(input.Length * ratio);

--- a/src/ElBruno.QwenTTS.VoiceCloning/ElBruno.QwenTTS.VoiceCloning.csproj
+++ b/src/ElBruno.QwenTTS.VoiceCloning/ElBruno.QwenTTS.VoiceCloning.csproj
@@ -15,7 +15,7 @@
     <PackageIcon>nuget_01.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>tts;text-to-speech;voice-cloning;qwen;onnx;ai;local;speech-synthesis;ecapa-tdnn;speaker-encoder</PackageTags>
-    <Version>1.0.0</Version>
+    <Version>1.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ElBruno.QwenTTS.VoiceCloning/ElBruno.QwenTTS.VoiceCloning.csproj
+++ b/src/ElBruno.QwenTTS.VoiceCloning/ElBruno.QwenTTS.VoiceCloning.csproj
@@ -19,6 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="ElBruno.QwenTTS.VoiceCloning.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\ElBruno.QwenTTS.Core\ElBruno.QwenTTS.Core.csproj" />
   </ItemGroup>
 

--- a/src/ElBruno.QwenTTS.VoiceCloning/Models/SpeechTokenizer.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Models/SpeechTokenizer.cs
@@ -54,31 +54,31 @@ internal sealed class SpeechTokenizer : IDisposable
         if (samples.Length == 0)
             throw new ArgumentException("Audio samples cannot be empty.", nameof(samples));
 
-        // Create input tensor: [1, num_samples]
-        var inputTensor = new DenseTensor<float>(samples, [1, samples.Length]);
+        // ONNX model expects input shape [B, 1, T_samples] (3D) named "audio_waveform"
+        var inputTensor = new DenseTensor<float>(samples, [1, 1, samples.Length]);
 
         var inputs = new List<NamedOnnxValue>
         {
-            NamedOnnxValue.CreateFromTensor("audio", inputTensor)
+            NamedOnnxValue.CreateFromTensor("audio_waveform", inputTensor)
         };
 
         using var results = GetSession().Run(inputs);
         var outputTensor = results.First().AsTensor<long>();
 
-        // Output shape: [1, T, 16]
+        // ONNX output shape: [B, 16, T_frames] — transpose to [B, T_frames, 16]
         var dims = outputTensor.Dimensions;
         int batch = dims[0];
-        int tFrames = dims[1];
-        int codebooks = dims[2];
+        int codebooks = dims[1];
+        int tFrames = dims[2];
 
         var codes = new long[batch, tFrames, codebooks];
         int idx = 0;
         foreach (var val in outputTensor)
         {
-            int b = idx / (tFrames * codebooks);
-            int t = (idx % (tFrames * codebooks)) / codebooks;
-            int c = idx % codebooks;
-            codes[b, t, c] = val;
+            int b = idx / (codebooks * tFrames);
+            int cb = (idx % (codebooks * tFrames)) / tFrames;
+            int t = idx % tFrames;
+            codes[b, t, cb] = val;
             idx++;
         }
 

--- a/src/ElBruno.QwenTTS.VoiceCloning/Models/SpeechTokenizer.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Models/SpeechTokenizer.cs
@@ -1,0 +1,106 @@
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+
+namespace ElBruno.QwenTTS.VoiceCloning.Models;
+
+/// <summary>
+/// Wraps the speech tokenizer encoder ONNX model.
+/// Encodes raw 24 kHz audio into quantized codec codes [1, T, 16].
+/// Used in ICL (In-Context Learning) mode to extract reference audio codes
+/// for higher-quality voice cloning.
+/// </summary>
+internal sealed class SpeechTokenizer : IDisposable
+{
+    private InferenceSession? _session;
+    private readonly string _modelPath;
+    private readonly Func<SessionOptions> _sessionOptionsFactory;
+
+    /// <summary>Expected sample rate for input audio.</summary>
+    public const int SampleRate = 24000;
+
+    /// <summary>Number of samples per codec frame.</summary>
+    public const int SamplesPerFrame = 1920;
+
+    /// <summary>Number of codebook groups in the output.</summary>
+    public const int NumCodebooks = 16;
+
+    public SpeechTokenizer(string modelPath, Func<SessionOptions>? sessionOptionsFactory = null)
+    {
+        if (!File.Exists(modelPath))
+            throw new FileNotFoundException("Speech tokenizer model not found.", modelPath);
+
+        _modelPath = modelPath;
+        _sessionOptionsFactory = sessionOptionsFactory ?? CreateDefaultOptions;
+    }
+
+    private static SessionOptions CreateDefaultOptions() => new()
+    {
+        GraphOptimizationLevel = GraphOptimizationLevel.ORT_ENABLE_ALL
+    };
+
+    private InferenceSession GetSession()
+    {
+        return _session ??= new InferenceSession(_modelPath, _sessionOptionsFactory());
+    }
+
+    /// <summary>
+    /// Encode raw audio samples into quantized codec codes.
+    /// </summary>
+    /// <param name="samples">PCM float32 samples at 24 kHz, mono.</param>
+    /// <returns>Codec codes of shape [1, T_frames, 16] where T_frames = ceil(num_samples / 1920).</returns>
+    public long[,,] Encode(float[] samples)
+    {
+        ArgumentNullException.ThrowIfNull(samples);
+        if (samples.Length == 0)
+            throw new ArgumentException("Audio samples cannot be empty.", nameof(samples));
+
+        // Create input tensor: [1, num_samples]
+        var inputTensor = new DenseTensor<float>(samples, [1, samples.Length]);
+
+        var inputs = new List<NamedOnnxValue>
+        {
+            NamedOnnxValue.CreateFromTensor("audio", inputTensor)
+        };
+
+        using var results = GetSession().Run(inputs);
+        var outputTensor = results.First().AsTensor<long>();
+
+        // Output shape: [1, T, 16]
+        var dims = outputTensor.Dimensions;
+        int batch = dims[0];
+        int tFrames = dims[1];
+        int codebooks = dims[2];
+
+        var codes = new long[batch, tFrames, codebooks];
+        int idx = 0;
+        foreach (var val in outputTensor)
+        {
+            int b = idx / (tFrames * codebooks);
+            int t = (idx % (tFrames * codebooks)) / codebooks;
+            int c = idx % codebooks;
+            codes[b, t, c] = val;
+            idx++;
+        }
+
+        return codes;
+    }
+
+    /// <summary>
+    /// Encode a WAV file into quantized codec codes.
+    /// Reads the WAV file, resamples to 24 kHz if needed, and encodes.
+    /// </summary>
+    /// <param name="wavPath">Path to a WAV file.</param>
+    /// <returns>Codec codes of shape [1, T_frames, 16].</returns>
+    public long[,,] EncodeFromWav(string wavPath)
+    {
+        var (samples, sampleRate) = Audio.MelSpectrogram.ReadWav(wavPath);
+        if (sampleRate != SampleRate)
+            samples = Audio.MelSpectrogram.Resample(samples, sampleRate, SampleRate);
+        return Encode(samples);
+    }
+
+    public void Dispose()
+    {
+        _session?.Dispose();
+    }
+}

--- a/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceClonePipeline.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceClonePipeline.cs
@@ -20,6 +20,9 @@ public sealed class VoiceClonePipeline : IDisposable
     private readonly Vocoder _vocoder;
     private readonly EmbeddingStore _embeddings;
     private readonly SpeakerEncoder _speakerEncoder;
+    private readonly string _modelDir;
+    private readonly Func<SessionOptions>? _sessionOptionsFactory;
+    private SpeechTokenizer? _speechTokenizer;
 
     /// <summary>
     /// Creates a VoiceClonePipeline from a local model directory.
@@ -28,6 +31,9 @@ public sealed class VoiceClonePipeline : IDisposable
     /// <param name="sessionOptionsFactory">Optional factory for ONNX Runtime session options (e.g., for GPU acceleration). When null, uses CPU with max optimization.</param>
     public VoiceClonePipeline(string modelDir, Func<SessionOptions>? sessionOptionsFactory = null)
     {
+        _modelDir = modelDir;
+        _sessionOptionsFactory = sessionOptionsFactory;
+
         var tokenizerDir = Path.Combine(modelDir, "tokenizer");
         var embeddingsDir = Path.Combine(modelDir, "embeddings");
         var configPath = Path.Combine(embeddingsDir, "config.json");
@@ -78,6 +84,48 @@ public sealed class VoiceClonePipeline : IDisposable
     }
 
     /// <summary>
+    /// Synthesize speech with a cloned voice using ICL (In-Context Learning) mode.
+    /// When refText is provided, the model uses both reference text and reference audio codes
+    /// for higher-quality voice cloning compared to speaker-embedding-only mode.
+    /// </summary>
+    /// <param name="text">Text to synthesize.</param>
+    /// <param name="referenceAudioPath">Path to a reference WAV file for voice cloning.</param>
+    /// <param name="outputPath">Path to save the output WAV file.</param>
+    /// <param name="refText">Transcript of the reference audio. Enables ICL mode when provided.</param>
+    /// <param name="language">Language code (e.g., "english", "chinese", "auto").</param>
+    /// <param name="progress">Optional progress callback.</param>
+    public async Task SynthesizeAsync(string text, string referenceAudioPath, string outputPath,
+                                      string? refText, string language = "auto", IProgress<string>? progress = null)
+    {
+        // Step 1: Extract speaker embedding from reference audio
+        progress?.Report("Extracting speaker embedding from reference audio...");
+        var speakerEmbedding = ExtractSpeakerEmbedding(referenceAudioPath);
+        progress?.Report($"Speaker embedding extracted ({speakerEmbedding.Length} dimensions)");
+
+        if (refText != null)
+        {
+            // ICL mode: also extract audio codes from reference audio
+            progress?.Report("Encoding reference audio for ICL mode...");
+            var speechTokenizer = GetSpeechTokenizer();
+            var refAudioCodes = speechTokenizer.EncodeFromWav(referenceAudioPath);
+            int tFrames = refAudioCodes.GetLength(1);
+            progress?.Report($"Reference audio encoded ({tFrames} frames)");
+
+            // Tokenize reference text
+            var refTokenIds = _tokenizer.Encode(refText);
+            progress?.Report($"Reference text tokenized ({refTokenIds.Length} tokens)");
+
+            await SynthesizeWithEmbeddingAsync(text, speakerEmbedding, outputPath,
+                refText: refText, refAudioCodes: refAudioCodes,
+                language: language, progress: progress);
+        }
+        else
+        {
+            await SynthesizeWithEmbeddingAsync(text, speakerEmbedding, outputPath, language, progress);
+        }
+    }
+
+    /// <summary>
     /// Synthesize speech using a pre-extracted speaker embedding.
     /// Use this when synthesizing multiple utterances with the same cloned voice
     /// to avoid re-encoding the reference audio each time.
@@ -85,13 +133,50 @@ public sealed class VoiceClonePipeline : IDisposable
     public async Task SynthesizeWithEmbeddingAsync(string text, float[] speakerEmbedding, string outputPath,
                                                     string language = "auto", IProgress<string>? progress = null)
     {
+        await SynthesizeWithEmbeddingAsync(text, speakerEmbedding, outputPath,
+            refText: null, refAudioCodes: null, language: language, progress: progress);
+    }
+
+    /// <summary>
+    /// Synthesize speech using a pre-extracted speaker embedding with optional ICL reference data.
+    /// When refText and refAudioCodes are provided, enables In-Context Learning mode.
+    /// </summary>
+    /// <param name="text">Text to synthesize.</param>
+    /// <param name="speakerEmbedding">Pre-extracted 1024-dim speaker embedding.</param>
+    /// <param name="outputPath">Path to save the output WAV file.</param>
+    /// <param name="refText">Optional reference text transcript for ICL mode.</param>
+    /// <param name="refAudioCodes">Optional reference audio codes [1, T, 16] for ICL mode.</param>
+    /// <param name="language">Language code (e.g., "english", "chinese", "auto").</param>
+    /// <param name="progress">Optional progress callback.</param>
+    public async Task SynthesizeWithEmbeddingAsync(string text, float[] speakerEmbedding, string outputPath,
+                                                    string? refText = null, long[,,]? refAudioCodes = null,
+                                                    string language = "auto", IProgress<string>? progress = null)
+    {
         var tokenIds = _tokenizer.BuildCustomVoicePrompt(text, "none", language, instruct: null);
         progress?.Report($"Tokenized input ({tokenIds.Length} tokens)");
         Console.WriteLine($"Generating speech ({tokenIds.Length} input tokens)...");
 
-        // Generate audio codes via LM with the ECAPA-TDNN speaker embedding injected into the codec prefix
+        // Tokenize reference text for ICL mode if provided
+        int[]? refTokenIds = null;
+        if (refText != null)
+        {
+            refTokenIds = _tokenizer.Encode(refText);
+            progress?.Report($"ICL mode: {refTokenIds.Length} ref text tokens, {refAudioCodes?.GetLength(1) ?? 0} ref audio frames");
+        }
+
+        // Generate audio codes via LM
         progress?.Report("Running language model inference...");
-        var codes = _languageModel.GenerateWithSpeakerEmbedding(tokenIds, speakerEmbedding, language);
+        long[,,] codes;
+        if (refTokenIds != null && refAudioCodes != null)
+        {
+            codes = _languageModel.GenerateWithSpeakerEmbeddingAndRefText(
+                tokenIds, speakerEmbedding, language,
+                refTokenIds: refTokenIds, refAudioCodes: refAudioCodes);
+        }
+        else
+        {
+            codes = _languageModel.GenerateWithSpeakerEmbedding(tokenIds, speakerEmbedding, language);
+        }
 
         int timesteps = codes.GetLength(2);
         progress?.Report($"Generated {timesteps} audio frames");
@@ -108,6 +193,26 @@ public sealed class VoiceClonePipeline : IDisposable
         var duration = waveform.Length / 24000.0;
         progress?.Report($"Saved {Path.GetFileName(outputPath)} ({waveform.Length} samples, {duration:F2}s)");
         Console.WriteLine($"Saved {outputPath} ({waveform.Length} samples, {duration:F2}s)");
+    }
+
+    /// <summary>
+    /// Gets or lazily creates the speech tokenizer for ICL mode.
+    /// The speech tokenizer ONNX model is optional — only needed when refText is provided.
+    /// </summary>
+    private SpeechTokenizer GetSpeechTokenizer()
+    {
+        if (_speechTokenizer != null)
+            return _speechTokenizer;
+
+        var modelPath = Path.Combine(_modelDir, "tokenizer12hz_encode.onnx");
+        if (!File.Exists(modelPath))
+            throw new FileNotFoundException(
+                "Speech tokenizer model not found. Required for ICL (ref_text) mode. " +
+                "Re-download the model or update VoiceCloningDownloader to include tokenizer12hz_encode.onnx.",
+                modelPath);
+
+        _speechTokenizer = new SpeechTokenizer(modelPath, _sessionOptionsFactory);
+        return _speechTokenizer;
     }
 
     /// <summary>
@@ -161,5 +266,6 @@ public sealed class VoiceClonePipeline : IDisposable
         _languageModel.Dispose();
         _vocoder.Dispose();
         _speakerEncoder.Dispose();
+        _speechTokenizer?.Dispose();
     }
 }

--- a/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceCloningDownloader.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceCloningDownloader.cs
@@ -34,6 +34,8 @@ public sealed class VoiceCloningDownloader
     [
         "speaker_encoder.onnx",
         "speaker_encoder.onnx.data",
+        "tokenizer12hz_encode.onnx",
+        "tokenizer12hz_encode.onnx.data",
         "talker_prefill.onnx",
         "talker_prefill.onnx.data",
         "talker_decode.onnx",


### PR DESCRIPTION
## Summary

Implements **ICL (In-Context Learning) mode** for voice cloning, enabling higher-quality voice clones by providing reference text alongside reference audio.

### Problem
Voice cloning with speaker-embedding-only mode (x_vector_only_mode) loses accent characteristics. For example, a Trump voice clone speaking Chinese sounds fully Chinese instead of retaining the English accent.

### Solution
When a reference text transcript is provided, the model uses both the reference text embeddings and extracted audio codec codes to preserve voice characteristics during cross-lingual synthesis.

### Changes

**New files:**
- \src/ElBruno.QwenTTS.VoiceCloning/Models/SpeechTokenizer.cs\ — ONNX wrapper for speech tokenizer encoder (audio → codec codes)
- \python/export_speech_tokenizer.py\ — Export script for speech tokenizer encoder to ONNX (209.6 MB model)

**Modified files:**
- \src/ElBruno.QwenTTS.Core/Models/LanguageModel.cs\ — New \GenerateWithSpeakerEmbeddingAndRefText()\ method; ICL prefill embedding logic
- \src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceClonePipeline.cs\ — New \SynthesizeAsync\ overload with \efText\ parameter; lazy-loaded SpeechTokenizer
- \src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceCloningDownloader.cs\ — Added \	okenizer12hz_encode.onnx\ to expected files
- \src/ElBruno.QwenTTS.VoiceCloning/ElBruno.QwenTTS.VoiceCloning.csproj\ — InternalsVisibleTo for tests, version bump
- \CHANGELOG.md\ — v1.4.0 entry

**Tests:** 249/249 passing (235 Core + 14 VoiceCloning, +4 new ICL tests)

### Usage
\\\csharp
// Existing API (unchanged)
await pipeline.SynthesizeAsync(text, referenceAudioPath, outputPath);

// New ICL mode with reference text
await pipeline.SynthesizeAsync(text, referenceAudioPath, outputPath, refText: "Hello, my name is Donald Trump.");
\\\

Closes #32