### PR TITLE
Fix Unicode encoding error on non-UTF-8 terminals

### DIFF
--- a/python/download_models.py
+++ b/python/download_models.py
@@ -19,6 +19,8 @@ Usage:
 import argparse
 import os
 from pathlib import Path
+
+from export_utils import configure_output_encoding
 from huggingface_hub import snapshot_download
 
 
@@ -61,6 +63,7 @@ MODELS_DIR = Path(__file__).parent / "models"
 
 
 def main():
+    configure_output_encoding()
     parser = argparse.ArgumentParser(description="Download Qwen3-TTS model weights")
     parser.add_argument(
         "--model",

--- a/python/download_onnx_models.py
+++ b/python/download_onnx_models.py
@@ -16,6 +16,8 @@ Usage:
 import argparse
 import os
 from pathlib import Path
+
+from export_utils import configure_output_encoding
 from huggingface_hub import hf_hub_download, list_repo_files
 
 
@@ -23,6 +25,7 @@ DEFAULT_REPO_ID = "elbruno/Qwen3-TTS-12Hz-0.6B-CustomVoice-ONNX"
 
 
 def main():
+    configure_output_encoding()
     parser = argparse.ArgumentParser(description="Download ONNX models from HuggingFace Hub")
     parser.add_argument(
         "--repo-id",

--- a/python/export_embeddings.py
+++ b/python/export_embeddings.py
@@ -32,6 +32,8 @@ import json
 import sys
 from pathlib import Path
 
+from export_utils import configure_output_encoding
+
 # Apply compatibility patches BEFORE importing qwen_tts.
 try:
     import compat_patches  # noqa: F401
@@ -57,6 +59,7 @@ def save_tensor(tensor, path):
 
 
 def main():
+    configure_output_encoding()
     parser = argparse.ArgumentParser(
         description="Extract embedding weights as NumPy arrays for C# inference"
     )

--- a/python/export_lm.py
+++ b/python/export_lm.py
@@ -29,6 +29,8 @@ import os
 import sys
 from pathlib import Path
 
+from export_utils import configure_output_encoding
+
 # Apply compatibility patches BEFORE importing qwen_tts or model code.
 # These fix vmap masking, RoPE init, sdpa_mask, torch.diff, and other
 # incompatibilities between qwen_tts and newer transformers versions.
@@ -378,6 +380,7 @@ def export_code_predictor(talker, output_dir, device, dims):
 # ═══════════════════════════════════════════════════════════════════════════
 
 def main():
+    configure_output_encoding()
     parser = argparse.ArgumentParser(
         description="Export Talker LM and Code Predictor to ONNX"
     )

--- a/python/export_speaker_encoder.py
+++ b/python/export_speaker_encoder.py
@@ -14,6 +14,8 @@ Usage:
 import argparse
 from pathlib import Path
 
+from export_utils import configure_output_encoding
+
 import numpy as np
 import torch
 import torch.nn as nn
@@ -132,6 +134,7 @@ def export_speaker_encoder(model_dir: str, output_dir: str):
 
 
 def main():
+    configure_output_encoding()
     parser = argparse.ArgumentParser(
         description="Export ECAPA-TDNN speaker encoder to ONNX"
     )

--- a/python/export_speech_tokenizer.py
+++ b/python/export_speech_tokenizer.py
@@ -29,6 +29,8 @@ import sys
 import time
 from pathlib import Path
 
+from export_utils import configure_output_encoding
+
 import numpy as np
 import torch
 import torch.nn as nn
@@ -550,6 +552,7 @@ def parse_args():
 
 
 def main():
+    configure_output_encoding()
     args = parse_args()
 
     output_dir = Path(args.output_dir) if args.output_dir else DEFAULT_OUTPUT_DIR

--- a/python/export_utils.py
+++ b/python/export_utils.py
@@ -11,7 +11,16 @@ Used by: export_lm.py, export_embeddings.py, export_vocoder.py,
 import json
 import os
 import re
+import sys
 from pathlib import Path
+
+
+def configure_output_encoding():
+    """Ensure stdout/stderr can handle Unicode on all platforms (e.g., GBK Windows)."""
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/python/export_vocoder.py
+++ b/python/export_vocoder.py
@@ -23,6 +23,8 @@ import numpy as np
 import torch
 from pathlib import Path
 
+from export_utils import configure_output_encoding
+
 # Compatibility patch: transformers 5.5+ changed check_model_inputs from a
 # decorator factory (@check_model_inputs()) to a plain decorator (@check_model_inputs).
 # The qwen_tts package still uses the old factory style, so we monkey-patch it
@@ -429,6 +431,7 @@ def parse_args():
 
 
 def main():
+    configure_output_encoding()
     global ONNX_OUTPUT_DIR, ONNX_OUTPUT_PATH
     args = parse_args()
 

--- a/python/extract_tokenizer.py
+++ b/python/extract_tokenizer.py
@@ -21,6 +21,7 @@ import json
 import os
 from pathlib import Path
 
+from export_utils import configure_output_encoding
 from transformers import AutoTokenizer
 
 DEFAULT_MODEL_ID = "Qwen/Qwen3-TTS-12Hz-0.6B-CustomVoice"
@@ -138,6 +139,7 @@ def save_special_tokens_summary(tokenizer, output_dir: Path) -> None:
 
 
 def main() -> None:
+    configure_output_encoding()
     parser = argparse.ArgumentParser(description="Extract BPE tokenizer artifacts for C#")
     parser.add_argument(
         "--model", type=str, default=DEFAULT_MODEL_ID,

--- a/python/test_voice_clone_onnx.py
+++ b/python/test_voice_clone_onnx.py
@@ -16,6 +16,8 @@ import soundfile as sf
 import onnxruntime as ort
 from librosa.filters import mel as librosa_mel_fn
 
+from export_utils import configure_output_encoding
+
 
 def compute_mel_pytorch_style(audio: np.ndarray, sr=24000, n_fft=1024, hop_size=256,
                                win_size=1024, n_mels=128, fmin=0, fmax=12000) -> np.ndarray:
@@ -76,6 +78,7 @@ def run_speaker_encoder(session: ort.InferenceSession, mel: np.ndarray) -> np.nd
 
 
 def main():
+    configure_output_encoding()
     parser = argparse.ArgumentParser(description="ONNX parity comparison for voice cloning")
     parser.add_argument("--onnx-dir", default=r"c:\models\QwenTTSVoiceClone",
                         help="Directory with ONNX models")

--- a/python/validate_vocoder.py
+++ b/python/validate_vocoder.py
@@ -17,6 +17,8 @@ import numpy as np
 import torch
 from pathlib import Path
 
+from export_utils import configure_output_encoding
+
 # ---------------------------------------------------------------------------
 # Compatibility patches (same as export_vocoder.py)
 # ---------------------------------------------------------------------------
@@ -203,6 +205,7 @@ def compare(decoder, session, batch_size: int, timesteps: int, label: str) -> di
 # Main
 # ---------------------------------------------------------------------------
 def main():
+    configure_output_encoding()
     parser = argparse.ArgumentParser(description="Validate vocoder ONNX export")
     parser.add_argument(
         "--model-dir", type=str, default=None,


### PR DESCRIPTION
## Problem

On Windows with non-UTF-8 terminal encodings (e.g., GBK on Chinese Windows), all Python export scripts crash with \UnicodeEncodeError: 'gbk' codec can't encode character '\u2717'\ when printing Unicode symbols like ✓, ✗, ⚠, →.

## Fix

Added a \configure_output_encoding()\ helper to \python/export_utils.py\ that reconfigures \stdout\/\stderr\ to UTF-8 with \rrors='replace'\. This is called at the top of \main()\ in all 10 affected scripts:

- \xport_speech_tokenizer.py\ (the file from the bug report)
- \xport_lm.py\
- \xport_vocoder.py\
- \xport_embeddings.py\
- \xport_speaker_encoder.py\
- \download_models.py\
- \download_onnx_models.py\
- \alidate_vocoder.py\
- \	est_voice_clone_onnx.py\
- \xtract_tokenizer.py\

Unicode symbols still display correctly on UTF-8 terminals; on GBK/other encodings they degrade gracefully via replacement characters instead of crashing.

All 62 existing Python tests pass.

Fixes #39