### PR TITLE
Fix ONNX cdist export error and handle missing HuggingFace files

### DIFF
--- a/python/compat_patches.py
+++ b/python/compat_patches.py
@@ -24,6 +24,9 @@ Patches applied:
        compatibility. The vmap-based masking in transformers 4.57+
        crashes during torch.onnx.export with:
        RuntimeError: invalid unordered_map<K, T> key
+    8. torch.cdist: ONNX symbolic export can't determine row_size_x1
+       statically, causing AssertionError in cdist. Replaced with
+       manual pairwise distance using basic tensor ops.
 """
 
 import torch
@@ -151,6 +154,34 @@ try:
     VMAP_WORKAROUND = "sdpa_without_vmap"
 except ImportError:
     pass  # transformers 5.5+ — vmap-free is the default
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 8. torch.cdist ONNX-safe replacement
+# ═══════════════════════════════════════════════════════════════════════════
+_orig_cdist = torch.cdist
+
+
+def _onnx_safe_cdist(x1, x2, p=2.0, compute_mode='use_mm_for_euclid_dist_if_necessary'):
+    """ONNX-safe replacement for torch.cdist.
+
+    The standard torch.cdist fails during ONNX trace export because
+    the symbolic function can't determine row_size_x1 statically.
+    This implementation uses basic tensor ops that ONNX can trace.
+    """
+    # x1: (..., P, M), x2: (..., R, M) → output: (..., P, R)
+    diff = x1.unsqueeze(-2) - x2.unsqueeze(-3)
+    if p == 2.0:
+        return (diff * diff).sum(-1).sqrt()
+    elif p == 1.0:
+        return diff.abs().sum(-1)
+    elif p == float('inf'):
+        return diff.abs().amax(-1)
+    else:
+        return diff.abs().pow(p).sum(-1).pow(1.0 / p)
+
+
+torch.cdist = _onnx_safe_cdist
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/python/export_speech_tokenizer.py
+++ b/python/export_speech_tokenizer.py
@@ -105,6 +105,29 @@ def _onnx_safe_cumsum(self, dim, dtype=None):
 
 torch.Tensor.cumsum = _onnx_safe_cumsum
 
+# Patch torch.cdist for ONNX trace (MimiSplitResidualVectorQuantizer codebook lookup)
+_orig_cdist = torch.cdist
+
+def _onnx_safe_cdist(x1, x2, p=2.0, compute_mode='use_mm_for_euclid_dist_if_necessary'):
+    """ONNX-safe replacement for torch.cdist.
+
+    The standard torch.cdist fails during ONNX trace export because
+    the symbolic function can't determine row_size_x1 statically.
+    This implementation uses basic tensor ops that ONNX can trace.
+    """
+    # x1: (..., P, M), x2: (..., R, M) → output: (..., P, R)
+    diff = x1.unsqueeze(-2) - x2.unsqueeze(-3)
+    if p == 2.0:
+        return (diff * diff).sum(-1).sqrt()
+    elif p == 1.0:
+        return diff.abs().sum(-1)
+    elif p == float('inf'):
+        return diff.abs().amax(-1)
+    else:
+        return diff.abs().pow(p).sum(-1).pow(1.0 / p)
+
+torch.cdist = _onnx_safe_cdist
+
 # Disable GQA in SDPA (not needed for Mimi — num_kv_heads == num_heads)
 import transformers.integrations.sdpa_attention as _sdpa_mod
 _sdpa_mod.use_gqa_in_sdpa = lambda attention_mask, key: False

--- a/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceCloningDownloader.cs
+++ b/src/ElBruno.QwenTTS.VoiceCloning/Pipeline/VoiceCloningDownloader.cs
@@ -87,6 +87,7 @@ public sealed class VoiceCloningDownloader
 
         int totalFiles = ExpectedFiles.Length;
         int currentFile = 0;
+        var skippedFiles = new List<string>();
 
         foreach (var relativePath in ExpectedFiles)
         {
@@ -109,27 +110,46 @@ public sealed class VoiceCloningDownloader
                 currentFile, totalFiles, relativePath,
                 $"[{currentFile}/{totalFiles}] Downloading {relativePath}...", 0, 0));
 
-            using var response = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-            response.EnsureSuccessStatusCode();
-
-            var totalBytes = response.Content.Headers.ContentLength ?? 0;
-            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
-            await using var fileStream = File.Create(localPath);
-
-            var buffer = new byte[81920];
-            long downloaded = 0;
-            int bytesRead;
-
-            while ((bytesRead = await contentStream.ReadAsync(buffer, cancellationToken)) > 0)
+            try
             {
-                await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
-                downloaded += bytesRead;
+                using var response = await http.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                response.EnsureSuccessStatusCode();
 
+                var totalBytes = response.Content.Headers.ContentLength ?? 0;
+                await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+                await using var fileStream = File.Create(localPath);
+
+                var buffer = new byte[81920];
+                long downloaded = 0;
+                int bytesRead;
+
+                while ((bytesRead = await contentStream.ReadAsync(buffer, cancellationToken)) > 0)
+                {
+                    await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
+                    downloaded += bytesRead;
+
+                    progress?.Report(new ModelDownloadProgress(
+                        currentFile, totalFiles, relativePath,
+                        $"[{currentFile}/{totalFiles}] {relativePath} ({downloaded:N0}/{totalBytes:N0} bytes)",
+                        downloaded, totalBytes));
+                }
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                skippedFiles.Add(relativePath);
                 progress?.Report(new ModelDownloadProgress(
                     currentFile, totalFiles, relativePath,
-                    $"[{currentFile}/{totalFiles}] {relativePath} ({downloaded:N0}/{totalBytes:N0} bytes)",
-                    downloaded, totalBytes));
+                    $"[{currentFile}/{totalFiles}] {relativePath} not found (404), skipped.", 0, 0));
             }
+        }
+
+        if (skippedFiles.Count > 0)
+        {
+            var fileList = string.Join(", ", skippedFiles);
+            progress?.Report(new ModelDownloadProgress(
+                totalFiles, totalFiles, "",
+                $"Warning: {skippedFiles.Count} file(s) not found on HuggingFace and were skipped: {fileList}. The model repository may not have been updated yet.",
+                0, 0));
         }
 
         progress?.Report(new ModelDownloadProgress(


### PR DESCRIPTION
## Changes

### Issue #42: ONNX export cdist assertion error
- Added torch.cdist ONNX-safe replacement patch to both compat_patches.py and export_speech_tokenizer.py
- The patch replaces torch.cdist with manual pairwise distance computation using basic tensor ops that ONNX can trace

### Issue #41: HuggingFace model files 404
- Added resilient HTTP error handling in VoiceCloningDownloader.DownloadModelAsync
- Files that return 404 are now skipped with a warning instead of crashing the entire download
- Other HTTP errors are still propagated

Fixes #42
Fixes #41